### PR TITLE
Fix #20: Add SHACL test suite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 		<module>geosparql</module>
 		<module>store</module>
 		<module>lucene</module>
+		<module>shacl</module>
 		<module>benchmark</module>
 	</modules>
 

--- a/shacl/pom.xml
+++ b/shacl/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-testsuites</artifactId>
+		<version>2.4-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>rdf4j-shacl-testsuite</artifactId>
+
+	<name>RDF4J SHACL compliance test suite</name>
+	<description>Test suite for the SHACL Shapes Constraint Language</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-client</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-storage</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.shacl.manifest;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.TestCase;
+
+/**
+ * A SHACL constraint test suite, created by reading in a W3C working-group style manifest.
+ * 
+ * @author James Leigh
+ */
+public abstract class AbstractSHACLTest extends TestCase {
+
+	/*-----------*
+	 * Constants *
+	 *-----------*/
+
+	// Logger for non-static tests, so these results can be isolated based on
+	// where they are run
+	protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	protected final String testURI;
+
+	protected final Model shapesGraph;
+
+	protected final Model dataGraph;
+
+	protected final boolean failure;
+
+	protected final boolean conforms;
+
+	/*-----------*
+	 * Variables *
+	 *-----------*/
+
+	protected Repository dataRep;
+	protected SailRepository shapesRep;
+
+	/*--------------*
+	 * Constructors *
+	 *--------------*/
+
+	public AbstractSHACLTest(String testURI, String label, Model shapesGraph, Model dataGraph,
+			boolean failure, boolean conforms)
+	{
+		super(label.replaceAll("\\(", " ").replaceAll("\\)", " "));
+
+		this.testURI = testURI;
+		this.shapesGraph = shapesGraph;
+		this.dataGraph = dataGraph;
+		this.failure = failure;
+		this.conforms = conforms;
+	}
+
+	/*---------*
+	 * Methods *
+	 *---------*/
+
+	@Override
+	public void setUp()
+		throws Exception
+	{
+		shapesRep = createShapesRepository();
+		if (shapesGraph != null) {
+			try {
+				upload(shapesRep, shapesGraph);
+			}
+			catch (Exception exc) {
+				try {
+					shapesRep.shutDown();
+					shapesRep = null;
+				}
+				catch (Exception e2) {
+					logger.error(e2.toString(), e2);
+				}
+				throw exc;
+			}
+		}
+		dataRep = createDataRepository(shapesRep);
+	}
+
+	protected SailRepository createShapesRepository()
+		throws Exception
+	{
+		SailRepository repo = new SailRepository(newSail());
+		repo.initialize();
+		RepositoryConnection con = repo.getConnection();
+		try {
+			con.clear();
+			con.clearNamespaces();
+		}
+		finally {
+			con.close();
+		}
+		return repo;
+	}
+
+	protected Repository createDataRepository(SailRepository shapesRep)
+		throws Exception
+	{
+		Repository repo = new SailRepository(newShaclSail(shapesRep));
+		repo.initialize();
+		RepositoryConnection con = repo.getConnection();
+		try {
+			con.clear();
+			con.clearNamespaces();
+		}
+		finally {
+			con.close();
+		}
+		return repo;
+	}
+
+	protected abstract Sail newSail();
+
+	protected abstract Sail newShaclSail(SailRepository shapesRep);
+
+	@Override
+	public void tearDown()
+		throws Exception
+	{
+		if (dataRep != null) {
+			dataRep.shutDown();
+			dataRep = null;
+		}
+	}
+
+	@Override
+	public void runTest()
+		throws Exception
+	{
+		try {
+			upload(dataRep, dataGraph);
+			assertTrue(conforms);
+		}
+		catch (RepositoryException exc) {
+			if (conforms || !(exc.getCause() instanceof SailException)) {
+				throw exc;
+			}
+		}
+	}
+
+	protected void upload(Repository rep, Model dataGraph) {
+		RepositoryConnection con = rep.getConnection();
+
+		try {
+			con.begin();
+			con.add(dataGraph);
+			con.commit();
+		}
+		catch (Exception e) {
+			if (con.isActive()) {
+				con.rollback();
+			}
+			throw e;
+		}
+		finally {
+			con.close();
+		}
+	}
+}

--- a/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
@@ -49,7 +49,6 @@ public abstract class AbstractSHACLTest extends TestCase {
 	 *-----------*/
 
 	protected Repository dataRep;
-	protected SailRepository shapesRep;
 
 	/*--------------*
 	 * Constructors *
@@ -75,29 +74,13 @@ public abstract class AbstractSHACLTest extends TestCase {
 	public void setUp()
 		throws Exception
 	{
-		shapesRep = createShapesRepository();
-		if (shapesGraph != null) {
-			try {
-				upload(shapesRep, shapesGraph);
-			}
-			catch (Exception exc) {
-				try {
-					shapesRep.shutDown();
-					shapesRep = null;
-				}
-				catch (Exception e2) {
-					logger.error(e2.toString(), e2);
-				}
-				throw exc;
-			}
-		}
-		dataRep = createDataRepository(shapesRep);
+		dataRep = createRepository(shapesGraph);
 	}
 
-	protected SailRepository createShapesRepository()
+	protected Repository createRepository(Model shapesGraph)
 		throws Exception
 	{
-		SailRepository repo = new SailRepository(newSail());
+		Repository repo = new SailRepository(newSail(shapesGraph));
 		repo.initialize();
 		RepositoryConnection con = repo.getConnection();
 		try {
@@ -110,25 +93,7 @@ public abstract class AbstractSHACLTest extends TestCase {
 		return repo;
 	}
 
-	protected Repository createDataRepository(SailRepository shapesRep)
-		throws Exception
-	{
-		Repository repo = new SailRepository(newShaclSail(shapesRep));
-		repo.initialize();
-		RepositoryConnection con = repo.getConnection();
-		try {
-			con.clear();
-			con.clearNamespaces();
-		}
-		finally {
-			con.close();
-		}
-		return repo;
-	}
-
-	protected abstract Sail newSail();
-
-	protected abstract Sail newShaclSail(SailRepository shapesRep);
+	protected abstract Sail newSail(Model shapesGraph);
 
 	@Override
 	public void tearDown()

--- a/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/SHACLManifestTestSuiteFactory.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/SHACLManifestTestSuiteFactory.java
@@ -1,0 +1,330 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.shacl.manifest;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.jar.JarFile;
+
+import org.eclipse.rdf4j.common.io.FileUtil;
+import org.eclipse.rdf4j.common.io.ZipUtil;
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
+import org.eclipse.rdf4j.rio.turtle.TurtleParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.Test;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
+
+/**
+ * Functionality for creating a JUnit test suite out of a W3C Working Group-style manifest for SHACL shape constraints testsuite
+ * 
+ * @author James Leigh
+ */
+public class SHACLManifestTestSuiteFactory {
+
+	private static final String MF_INCLUDE = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#include";
+	private static final String MF_ENTRIES = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries";
+	private static final String MF_ACTION = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action";
+	private static final String MF_RESULT = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result";
+	private static final String MF_STATUS = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#status";
+	private static final String SHT_SHAPESGRAPH = "http://www.w3.org/ns/shacl-test#shapesGraph";
+	private static final String SHT_DATAGRAPH = "http://www.w3.org/ns/shacl-test#dataGraph";
+	private static final String SHT_PROPOSED = "http://www.w3.org/ns/shacl-test#proposed";
+	private static final String SHT_APPROVED = "http://www.w3.org/ns/shacl-test#approved";
+	private static final String SHT_FAILURE = "http://www.w3.org/ns/shacl-test#Failure";
+	private static final String SH_CONFORMS = "http://www.w3.org/ns/shacl#conforms";
+
+	private final Logger logger = LoggerFactory.getLogger(SHACLManifestTestSuiteFactory.class);
+
+	private File tmpDir;
+
+	public interface TestFactory {
+		String getName();
+		Test createSHACLTest(String testURI, String label, Model shapesGraph, Model dataGraph,
+				boolean failure, boolean conforms);
+	}
+
+	/**
+	 * Creates a new {@link TestSuite} for executiong of {@link AbstractSHACLTest} s.
+	 * 
+	 * @param factory
+	 *        a factory class that creates each individual test case.
+	 * @param officialWorkingGroupTests
+	 *        indicates whether to use the official W3C working group tests, or Sesame's own set of tests.
+	 * @param approvedTestsOnly
+	 *        if <code>true</code>, use working group-approved tests only. Has no influence when
+	 *        officialWorkingGroup tests is set to <code>false</code>.
+	 * @param useRemoteTests
+	 *        if set to <code>true</code>, use manifests and tests located at
+	 *        <code>http://www.w3.org/2009/sparql/docs/tests/data-sparql11/</code> , instead of local copies.
+	 * @param excludedSubdirs
+	 *        an (optionally empty) list of subdirectories to exclude from testing. If specified, test cases
+	 *        in one of the supplied subdirs will not be executed. If left empty, all tests will be executed.
+	 * @return a TestSuite.
+	 * @throws Exception
+	 */
+	public TestSuite createTestSuite(TestFactory factory, boolean officialWorkingGroupTests,
+			boolean approvedTestsOnly, boolean useRemoteTests, String... excludedSubdirs)
+		throws Exception
+	{
+		final String manifest = getManifestFile(officialWorkingGroupTests, useRemoteTests);
+
+		TestSuite suite = new TestSuite(factory.getName()) {
+
+			@Override
+			public void run(TestResult result) {
+				try {
+					super.run(result);
+				}
+				finally {
+					if (tmpDir != null) {
+						try {
+							FileUtil.deleteDir(tmpDir);
+						}
+						catch (IOException e) {
+							System.err.println("Unable to clean up temporary directory '" + tmpDir + "': "
+									+ e.getMessage());
+						}
+					}
+				}
+			}
+		};
+
+		Map<String, TestSuite> tests = new LinkedHashMap<>();
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		Model manifests = new LinkedHashModel();
+		readTurtle(manifests, new URL(manifest), manifest, excludedSubdirs);
+		for (Value included : manifests.filter(null, vf.createIRI(MF_INCLUDE), null).objects()) {
+			String subManifestFile = included.stringValue();
+			boolean hasEntries = manifests.contains((IRI) included,  vf.createIRI(MF_ENTRIES), null);
+			if (hasEntries && includeSubManifest(subManifestFile, excludedSubdirs)) {
+				TestSuite suiteEntry = createSuiteEntry(subManifestFile, factory, approvedTestsOnly);
+				if (tests.containsKey(suiteEntry.getName())) {
+					for (int i=0,n=suiteEntry.testCount(); i<n; i++) {
+						tests.get(suiteEntry.getName()).addTest(suiteEntry.testAt(i));
+					}
+				} else {
+					tests.put(suiteEntry.getName(), suiteEntry);
+				}
+			}
+		}
+		for (TestSuite testSuiets : tests.values()) {
+			suite.addTest(testSuiets);
+		}
+
+		logger.info("Created aggregated test suite with " + suite.countTestCases() + " test cases.");
+		return suite;
+	}
+
+	private String getManifestFile(boolean officialWorkingGroupTests, boolean useRemote) {
+		if (useRemote) {
+			return "https://raw.githubusercontent.com/w3c/data-shapes/gh-pages/data-shapes-test-suite/tests/manifest.ttl";
+		}
+		URL url = SHACLManifestTestSuiteFactory.class.getResource("/data-shapes-test-suite/tests/manifest.ttl");
+		if ("jar".equals(url.getProtocol())) {
+			// Extract manifest files to a temporary directory
+			try {
+				tmpDir = FileUtil.createTempDir("data-shapes-test-evaluation");
+
+				JarURLConnection con = (JarURLConnection)url.openConnection();
+				JarFile jar = con.getJarFile();
+
+				ZipUtil.extract(jar, tmpDir);
+
+				File localFile = new File(tmpDir, con.getEntryName());
+				return localFile.toURI().toURL().toString();
+			}
+			catch (IOException e) {
+				throw new AssertionError(e);
+			}
+		}
+		else {
+			return url.toString();
+		}
+	}
+
+	private IRI readTurtle(Model manifests, URL url, String baseURI, String...excludedSubdirs)
+		throws IOException, RDFParseException
+	{
+		if (baseURI == null) {
+			baseURI = url.toExternalForm();
+		}
+		ParsedIRI baseIRI = ParsedIRI.create(baseURI);
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		IRI manifest = vf.createIRI(baseIRI.toString());
+		int before = manifests.size();
+
+		InputStream in = url.openStream();
+
+		try {
+			RDFParser rdfParser = new TurtleParser();
+
+			ContextStatementCollector collection = new ContextStatementCollector(manifests, vf, manifest);
+			rdfParser.setRDFHandler(collection);
+
+			rdfParser.parse(in, baseIRI.toString());
+			for (Map.Entry<String, String> e : collection.getNamespaces().entrySet()) {
+				manifests.setNamespace(e.getKey(), e.getValue());
+			}
+		}
+		finally {
+			in.close();
+		}
+		if (before < manifests.size()) {
+			for (Value included : new LinkedHashSet<Value>(manifests.filter(manifest, vf.createIRI(MF_INCLUDE), null).objects())) {
+				String subManifestFile = included.stringValue();
+				if (includeSubManifest(subManifestFile, excludedSubdirs)) {
+					readTurtle(manifests, new URL(subManifestFile), subManifestFile, excludedSubdirs);
+				}
+			}
+		}
+		return manifest;
+	}
+
+	/**
+	 * Verifies if the selected subManifest occurs in the supplied list of excluded subdirs.
+	 * 
+	 * @param subManifestFile
+	 *        the url of a sub-manifest
+	 * @param excludedSubdirs
+	 *        an array of directory names. May be null.
+	 * @return <code>false</code> if the supplied list of excluded subdirs is not empty and contains a match
+	 *         for the supplied sub-manifest, <code>true</code> otherwise.
+	 */
+	private boolean includeSubManifest(String subManifestFile, String[] excludedSubdirs) {
+		boolean result = true;
+
+		if (excludedSubdirs != null && excludedSubdirs.length > 0) {
+			int index = subManifestFile.lastIndexOf("/");
+			String path = subManifestFile.substring(0, index);
+			String sd = path.substring(path.lastIndexOf("/") + 1);
+
+			for (String subdir : excludedSubdirs) {
+				if (sd.equals(subdir)) {
+					result = false;
+					break;
+				}
+			}
+		}
+		return result;
+	}
+
+	private TestSuite createSuiteEntry(String manifestFileURL, TestFactory factory, boolean approvedOnly)
+		throws Exception
+	{
+		logger.info("Building test suite for {}", manifestFileURL);
+
+		// Read manifest and create declared test cases
+		Model model = new LinkedHashModel();
+
+		IRI manifest = readTurtle(model, new URL(manifestFileURL), manifestFileURL);
+
+
+		TestSuite suite = new TestSuite(getManifestName(model, manifest));
+
+		// Extract test case information from the manifest file. Note that we only
+		// select those test cases that are mentioned in the list.
+		Resource rdfList = getResource(model, manifest, MF_ENTRIES);
+		for (Resource entry : getListEntries(model, rdfList)) {
+			String label = getLiteral(model, entry, RDFS.LABEL.stringValue()).stringValue();
+			Resource action = getResource(model, entry, MF_ACTION);
+			Resource result = getResource(model, entry, MF_RESULT);
+			Resource status = getResource(model, entry, MF_STATUS);
+			Model shapesGraph = readTurtle(getResource(model, action, SHT_SHAPESGRAPH).stringValue());
+			Model dataGraph = readTurtle(getResource(model, action, SHT_DATAGRAPH).stringValue());
+			boolean failure = result.stringValue().equals(SHT_FAILURE);
+			boolean conforms = !failure && getLiteral(model, result, SH_CONFORMS).booleanValue();
+
+			logger.debug("found test case : {}", label);
+
+			if (status.stringValue().equals(SHT_APPROVED) || !approvedOnly && status.stringValue().equals(SHT_PROPOSED)) {
+				Test test = factory.createSHACLTest(entry.stringValue(), label, shapesGraph, dataGraph, failure, conforms);
+				if (test != null) {
+					suite.addTest(test);
+				}
+			}
+		}
+
+		logger.info("Created test suite with " + suite.countTestCases() + " test cases.");
+		return suite;
+	}
+
+	private String getManifestName(Model model, IRI manifest)
+		throws QueryEvaluationException, RepositoryException, MalformedQueryException
+	{
+		// Try to extract suite name from manifest file
+		String label = Models.objectString(model.filter(manifest, RDFS.LABEL, null)).orElse(null);
+		if (label != null) {
+			return label;
+		}
+
+		// Derive name from manifest URL
+		String manifestFileURL = manifest.stringValue();
+		int lastSlashIdx = manifestFileURL .lastIndexOf('/');
+		int secLastSlashIdx = manifestFileURL.lastIndexOf('/', lastSlashIdx - 1);
+		return manifestFileURL.substring(secLastSlashIdx + 1, lastSlashIdx);
+	}
+
+	private List<Resource> getListEntries(Model model, Resource rdfList) {
+		if (rdfList == null || rdfList.equals(RDF.NIL)) {
+			return new ArrayList<Resource>();
+		}
+		Resource first = Models.objectResource(model.filter(rdfList, RDF.FIRST, null)).orElse(null);
+		Resource rest = Models.objectResource(model.filter(rdfList, RDF.REST, null)).orElse(null);
+		List<Resource> list = getListEntries(model, rest);
+		list.add(0, first);
+		return list;
+	}
+
+	private Resource getResource(Model model, Resource subject, String pred) {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		Optional<Resource> optional = Models.objectResource(model.filter(subject, vf.createIRI(pred), null));
+		return optional.orElseThrow(Models.modelException("Missing " + subject + " " + pred));
+	}
+
+	private Literal getLiteral(Model model, Resource subject, String pred) {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		Optional<Literal> optional = Models.objectLiteral(model.filter(subject, vf.createIRI(pred), null));
+		return optional.orElseThrow(Models.modelException("Missing " + subject + " " + pred));
+	}
+
+	private Model readTurtle(String url) throws RDFParseException, MalformedURLException, IOException {
+		Model model = new LinkedHashModel();
+		readTurtle(model, new URL(url), url);
+		return model;
+	}
+}

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/manifest.ttl
@@ -1,0 +1,10 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/complex" ;
+	mf:include <personexample.ttl> ;
+	mf:include <shacl-shacl.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/personexample.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/personexample.ttl
@@ -1,0 +1,103 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/complex/personexample.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Alice
+  rdf:type ex:Person ;
+  ex:ssn "987-65-432A" ;
+.
+ex:Bob
+  rdf:type ex:Person ;
+  ex:ssn "123-45-6789" ;
+  ex:ssn "124-35-6789" ;
+.
+ex:Calvin
+  rdf:type ex:Person ;
+  ex:birthDate "1999-09-09"^^xsd:date ;
+  ex:worksFor ex:UntypedCompany ;
+.
+ex:PersonShape
+  rdf:type sh:NodeShape ;
+  sh:closed "true"^^xsd:boolean ;
+  sh:ignoredProperties (
+      rdf:type
+    ) ;
+  sh:property [
+      sh:path ex:ssn ;
+      sh:datatype xsd:string ;
+      sh:maxCount 1 ;
+      sh:pattern "^\\d{3}-\\d{2}-\\d{4}$" ;
+    ] ;
+  sh:property [
+      sh:path ex:worksFor ;
+      sh:class ex:Company ;
+      sh:nodeKind sh:IRI ;
+    ] ;
+  sh:property [
+      sh:path [
+          sh:inversePath ex:worksFor ;
+        ] ;
+      sh:name "employee" ;
+    ] ;
+  sh:targetClass ex:Person ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <personexample>
+    ) ;
+.
+<personexample>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of personexample" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Alice ;
+          sh:resultPath ex:ssn ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape _:b61064 ;
+          sh:value "987-65-432A" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Bob ;
+          sh:resultPath ex:ssn ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape _:b61064 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Calvin ;
+          sh:resultPath ex:birthDate ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
+          sh:sourceShape ex:PersonShape ;
+          sh:value "1999-09-09"^^xsd:date ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Calvin ;
+          sh:resultPath ex:worksFor ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape [] ;
+          sh:value ex:UntypedCompany ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/shacl-shacl-data-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/shacl-shacl-data-shapes.ttl
@@ -1,0 +1,410 @@
+# baseURI: http://www.w3.org/ns/shacl-shacl#
+
+# A SHACL shapes graph to validate SHACL shapes graphs
+# Draft last edited 2017-04-04
+
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix shsh: <http://www.w3.org/ns/shacl-shacl#> .
+
+shsh:
+	rdfs:label "SHACL for SHACL"@en ;
+	rdfs:comment "This shapes graph can be used to validate SHACL shapes graphs against a subset of the syntax rules."@en ;
+	sh:declare [
+		sh:prefix "shsh" ;
+		sh:namespace "http://www.w3.org/ns/shacl-shacl#" ;
+	] .
+
+	
+shsh:ListShape
+	a sh:NodeShape ;
+	rdfs:label "List shape"@en ;
+	rdfs:comment "A shape describing well-formed RDF lists. Currently does not check for non-recursion. This could be expressed using SHACL-SPARQL."@en ;
+	rdfs:seeAlso <https://www.w3.org/TR/shacl/#syntax-rule-SHACL-list> ;
+	sh:property [
+		sh:path [ sh:zeroOrMorePath rdf:rest ] ;
+		rdfs:comment "Each list member (including this node) must be have the shape shsh:ListNodeShape."@en ;
+		sh:hasValue rdf:nil ;
+		sh:node shsh:ListNodeShape ;
+	] .
+
+shsh:ListNodeShape
+	a sh:NodeShape ;
+	rdfs:label "List node shape"@en ;
+	rdfs:comment "Defines constraints on what it means for a node to be a node within a well-formed RDF list. Note that this does not check whether the rdf:rest items are also well-formed lists as this would lead to unsupported recursion."@en ;
+	sh:or ( [
+				sh:hasValue rdf:nil ;
+        		sh:property [
+					sh:path rdf:first ;
+					sh:maxCount 0 ;
+				] ;
+				sh:property [
+					sh:path rdf:rest ;
+					sh:maxCount 0 ;
+				] ;
+			]
+			[
+				sh:not [ sh:hasValue rdf:nil ] ;
+				sh:property [
+					sh:path rdf:first ;
+					sh:maxCount 1 ;
+					sh:minCount 1 ;
+				] ;
+				sh:property [
+					sh:path rdf:rest ;
+					sh:maxCount 1 ;
+					sh:minCount 1 ;
+				] ;
+			] ) .
+
+shsh:ShapeShape
+	a sh:NodeShape ;
+	rdfs:label "Shape shape"@en ;
+	rdfs:comment "A shape that can be used to validate syntax rules for other shapes."@en ;
+	
+	# See https://www.w3.org/TR/shacl/#shapes for what counts as a shape
+	sh:targetClass sh:NodeShape ;
+	sh:targetClass sh:PropertyShape ;
+	sh:targetSubjectsOf sh:targetClass, sh:targetNode, sh:targetObjectsOf, sh:targetSubjectsOf ;
+	sh:targetSubjectsOf sh:and, sh:class, sh:closed, sh:datatype, sh:disjoint, sh:equals, sh:flags, sh:hasValue,
+		sh:ignoredProperties, sh:in, sh:languageIn, sh:lessThan, sh:lessThanOrEquals, sh:maxCount, sh:maxExclusive,
+		sh:maxInclusive, sh:maxLength, sh:minCount, sh:minExclusive, sh:minInclusive, sh:minLength, sh:node, sh:nodeKind,
+		sh:not, sh:or, sh:pattern, sh:property, sh:qualifiedMaxCount, sh:qualifiedMinCount, sh:qualifiedValueShape,
+		sh:qualifiedValueShape, sh:qualifiedValueShapesDisjoint, sh:qualifiedValueShapesDisjoint, sh:sparql, sh:uniqueLang, sh:xone ;
+
+	sh:targetObjectsOf sh:node ;        # node-node
+	sh:targetObjectsOf sh:not ;         # not-node
+	sh:targetObjectsOf sh:property ;    # property-node
+	sh:targetObjectsOf sh:qualifiedValueShape ; # qualifiedValueShape-node
+
+	# Shapes are either node shapes or property shapes
+	sh:xone ( shsh:NodeShapeShape shsh:PropertyShapeShape ) ;
+
+	sh:property [
+		sh:path sh:targetNode ;
+		sh:nodeKind	sh:IRIOrLiteral ;   # targetNode-nodeKind
+	] ; 
+	sh:property [
+		sh:path sh:targetClass ;
+		sh:nodeKind sh:IRI ;            # targetClass-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:targetSubjectsOf ;
+		sh:nodeKind sh:IRI ;            # targetSubjectsOf-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:targetObjectsOf ;
+		sh:nodeKind sh:IRI ;            # targetObjectsOf-nodeKind
+	] ;
+	sh:or ( [ sh:not [ 
+				sh:class rdfs:Class ; 
+				sh:or ( [ sh:class sh:NodeShape ] [ sh:class sh:PropertyShape ] )
+			] ]
+			[ sh:nodeKind sh:IRI ]
+		  ) ;                           # implicit-targetClass-nodeKind
+	
+	sh:property [
+		sh:path sh:severity ;
+		sh:maxCount 1 ;                 # severity-maxCount
+		sh:nodeKind sh:IRI ;            # severity-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:message ;
+		sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;   # message-datatype
+	] ;
+	sh:property [
+		sh:path sh:deactivated ;
+		sh:maxCount 1 ;                 # deactivated-maxCount
+		sh:in ( true false ) ;          # deactivated-datatype
+	] ;
+
+	sh:property [
+		sh:path sh:and ;
+		sh:node shsh:ListShape ;        # and-node
+	] ;
+	sh:property [
+		sh:path sh:class ;
+		sh:nodeKind sh:IRI ;            # class-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:closed ;
+		sh:datatype xsd:boolean ;       # closed-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:ignoredProperties ;
+		sh:node shsh:ListShape ;        # ignoredProperties-node
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path ( sh:ignoredProperties [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+		sh:nodeKind sh:IRI ;            # ignoredProperties-members-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:datatype ;
+		sh:nodeKind sh:IRI ;            # datatype-nodeKind
+		sh:maxCount 1 ;                 # datatype-maxCount
+	] ;
+	sh:property [
+		sh:path sh:disjoint ;
+		sh:nodeKind sh:IRI ;            # disjoint-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:equals ;
+		sh:nodeKind sh:IRI ;            # equals-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:in ;
+		sh:maxCount 1 ;                 # in-maxCount		
+		sh:node shsh:ListShape ;        # in-node
+	] ;
+	sh:property [
+		sh:path sh:languageIn ;
+		sh:maxCount 1 ;                 # languageIn-maxCount
+		sh:node shsh:ListShape ;        # languageIn-node
+	] ;
+	sh:property [
+		sh:path ( sh:languageIn [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+		sh:datatype xsd:string ;        # languageIn-members-datatype
+	] ;
+	sh:property [
+		sh:path sh:lessThan ;
+		sh:nodeKind sh:IRI ;            # lessThan-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:lessThanOrEquals ;
+		sh:nodeKind sh:IRI ;            # lessThanOrEquals-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:maxCount ;
+		sh:datatype xsd:integer ;       # maxCount-datatype
+		sh:maxCount 1 ;                 # maxCount-maxCount
+	] ;
+	sh:property [
+		sh:path sh:maxExclusive ;
+		sh:maxCount 1 ;                 # maxExclusive-maxCount
+		sh:nodeKind sh:Literal ;        # maxExclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:maxInclusive ;
+		sh:maxCount 1 ;                 # maxInclusive-maxCount
+		sh:nodeKind sh:Literal ;        # maxInclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:maxLength ;
+		sh:datatype xsd:integer ;       # maxLength-datatype
+		sh:maxCount 1 ;                 # maxLength-maxCount
+	] ;
+	sh:property [
+		sh:path sh:minCount ;
+		sh:datatype xsd:integer ;       # minCount-datatype
+		sh:maxCount 1 ;                 # minCount-maxCount
+	] ;
+	sh:property [
+		sh:path sh:minExclusive ;
+		sh:maxCount 1 ;                 # minExclusive-maxCount
+		sh:nodeKind sh:Literal ;        # minExclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:minInclusive ;
+		sh:maxCount 1 ;                 # minInclusive-maxCount
+		sh:nodeKind sh:Literal ;        # minInclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:minLength ;
+		sh:datatype xsd:integer ;       # minLength-datatype
+		sh:maxCount 1 ;                 # minLength-maxCount
+	] ;
+	sh:property [
+		sh:path sh:nodeKind ;
+		sh:in ( sh:BlankNode sh:IRI sh:Literal sh:BlankNodeOrIRI sh:BlankNodeOrLiteral sh:IRIOrLiteral ) ;	# nodeKind-in
+		sh:maxCount 1 ;                 # nodeKind-maxCount
+	] ;
+	sh:property [
+		sh:path sh:or ;
+		sh:node shsh:ListShape ;        # or-node
+	] ;
+	sh:property [
+		sh:path sh:pattern ;
+		sh:datatype xsd:string ;        # pattern-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+		# Not implemented: syntax rule pattern-regex
+	] ;
+	sh:property [
+		sh:path sh:flags ;
+		sh:datatype xsd:string ;        # flags-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedMaxCount ;
+		sh:datatype xsd:integer ;       # qualifiedMaxCount-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedMinCount ;
+		sh:datatype xsd:integer ;       # qualifiedMinCount-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedValueShape ;
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedValueShapesDisjoint ;
+		sh:datatype xsd:boolean ;       # qualifiedValueShapesDisjoint-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:uniqueLang ;
+		sh:datatype xsd:boolean ;       # uniqueLang-datatype
+		sh:maxCount 1 ;                 # uniqueLang-maxCount
+	] ;
+	sh:property [
+		sh:path sh:xone ;
+		sh:node shsh:ListShape ;        # xone-node
+	] .
+	
+shsh:NodeShapeShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:node ;        # node-node
+	sh:property [
+		sh:path sh:path ;
+		sh:maxCount 0 ;                 # NodeShape-path-maxCount
+	] ;
+	sh:property [
+		sh:path sh:lessThan ;
+		sh:maxCount 0 ;                 # lessThan-scope
+	] ;
+	sh:property [
+		sh:path sh:lessThanOrEquals ;
+		sh:maxCount 0 ;                 # lessThanOrEquals-scope
+	] ;
+	sh:property [
+		sh:path sh:maxCount ;
+		sh:maxCount 0 ;                 # maxCount-scope
+	] ;
+	sh:property [
+		sh:path sh:minCount ;
+		sh:maxCount 0 ;                 # minCount-scope
+	] ;
+	sh:property [
+		sh:path sh:qualifiedValueShape ;
+		sh:maxCount 0 ;                 # qualifiedValueShape-scope
+	] ;
+	sh:property [
+		sh:path sh:uniqueLang ;
+		sh:maxCount 0 ;                 # uniqueLang-scope
+	] .
+
+shsh:PropertyShapeShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:property ;    # property-node
+	sh:property [
+		sh:path sh:path ;
+		sh:maxCount 1 ;                 # path-maxCount
+		sh:minCount 1 ;                 # PropertyShape-path-minCount
+		sh:node shsh:PathShape ;        # path-node
+	] .
+
+# Values of sh:and, sh:or and sh:xone must be lists of shapes
+shsh:ShapesListShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:and ;         # and-members-node
+	sh:targetObjectsOf sh:or ;          # or-members-node
+	sh:targetObjectsOf sh:xone ;        # xone-members-node
+	sh:property [
+		sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+		sh:node shsh:ShapeShape ;
+	] .
+
+
+# A path of blank node path syntax, used to simulate recursion
+_:PathPath
+	sh:alternativePath (
+		( [ sh:zeroOrMorePath rdf:rest ] rdf:first )
+		( sh:alternativePath [ sh:zeroOrMorePath rdf:rest ] rdf:first )
+		sh:inversePath
+		sh:zeroOrMorePath
+		sh:oneOrMorePath
+		sh:zeroOrOnePath 
+	) .
+
+shsh:PathShape
+	a sh:NodeShape ;
+	rdfs:label "Path shape"@en ;
+	rdfs:comment "A shape that can be used to validate the syntax rules of well-formed SHACL paths."@en ;
+	rdfs:seeAlso <https://www.w3.org/TR/shacl/#property-paths> ;
+	sh:property [
+		sh:path [ sh:zeroOrMorePath _:PathPath ] ;
+		sh:node shsh:PathNodeShape ;
+	] .
+
+shsh:PathNodeShape
+	sh:xone (                           # path-metarule
+			[ sh:nodeKind sh:IRI ]          # 2.3.1.1: Predicate path
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.2: Sequence path
+			  sh:node shsh:PathListWithAtLeast2Members ;
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.3: Alternative path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:alternativePath ;
+			    sh:node shsh:PathListWithAtLeast2Members ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ]
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.4: Inverse path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:inversePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ] 
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.5: Zero-or-more path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:zeroOrMorePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ] 
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.6: One-or-more path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:oneOrMorePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ] 
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.7: Zero-or-one path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:zeroOrOnePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ] 
+			]
+		) .
+
+shsh:PathListWithAtLeast2Members
+	a sh:NodeShape ;
+	sh:node shsh:ListShape ;
+	sh:property [
+		sh:path [ sh:oneOrMorePath rdf:rest ] ;
+		sh:minCount 2 ;    # 1 other list node plus rdf:nil
+	] .
+
+shsh:ShapesGraphShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:shapesGraph ;
+	sh:nodeKind sh:IRI .                # shapesGraph-nodeKind
+
+shsh:EntailmentShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:entailment ;
+	sh:nodeKind sh:IRI .                # entailment-nodeKind

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/shacl-shacl.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/complex/shacl-shacl.ttl
@@ -1,0 +1,19 @@
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+
+<> a mf:Manifest ;
+  mf:entries (
+      <shacl-shacl>
+    ) .
+
+<shacl-shacl> a sht:Validate ;
+  rdfs:label "frozen eat your own ( eat your own frozen dogfood )" ;
+  mf:action [
+      sht:dataGraph <shacl-shacl-data-shapes.ttl> ;
+      sht:shapesGraph <shacl-shacl-data-shapes.ttl> ] ;
+  mf:result [a sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/manifest.ttl
@@ -1,0 +1,14 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	mf:include <complex/manifest.ttl> ;
+	mf:include <misc/manifest.ttl> ;
+	mf:include <node/manifest.ttl> ;
+	mf:include <path/manifest.ttl> ;
+	mf:include <property/manifest.ttl> ;
+	mf:include <targets/manifest.ttl> ;
+	mf:include <validation-reports/manifest.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/deactivated-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/deactivated-001.ttl
@@ -1,0 +1,44 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource
+  rdf:type rdfs:Resource ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:boolean ;
+  sh:deactivated "true"^^xsd:boolean ;
+  sh:property ex:TestShape2 ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape2
+  rdf:type sh:PropertyShape ;
+  sh:path ex:property ;
+  sh:minCount 1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <deactivated-001>
+    ) ;
+.
+<deactivated-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:deactivated 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/deactivated-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/deactivated-002.ttl
@@ -1,0 +1,43 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/misc/deactivated-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:boolean ;
+  sh:deactivated "false"^^xsd:boolean ;
+  sh:targetNode 32 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <deactivated-002>
+    ) ;
+.
+<deactivated-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:deactivated 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 32 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 32 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/manifest.ttl
@@ -1,0 +1,13 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/misc" ;
+	mf:include <deactivated-001.ttl> ;
+	mf:include <deactivated-002.ttl> ;
+	mf:include <message-001.ttl> ;
+	mf:include <severity-001.ttl> ;
+	mf:include <severity-002.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/message-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/message-001.ttl
@@ -1,0 +1,48 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/misc/message-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer ;
+  sh:message "Test message"@en ;
+  sh:targetNode ex:InvalidNode ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <message-001>
+    ) ;
+.
+<message-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of custom sh:message 001" ;
+  rdfs:comment """
+  		Note: This test verifies that the sh:message is copied into sh:resultMessage.
+  		To pass this test, the test harness needs to preserve all sh:resultMessage triples
+  		that are mentioned in the 'expected' results graph.""" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidNode ;
+          sh:resultMessage "Test message"@en ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidNode ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/severity-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/severity-001.ttl
@@ -1,0 +1,43 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer ;
+  sh:severity sh:Warning ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <severity-001>
+    ) ;
+.
+<severity-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:severity 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Warning ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/severity-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/misc/severity-002.ttl
@@ -1,0 +1,60 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/misc/severity-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property "true"^^xsd:boolean ;
+.
+ex:TestShape1
+  sh:nodeKind sh:BlankNode ;
+  sh:property ex:TestShape2 ;
+  sh:severity ex:MySeverity ;
+  sh:targetNode ex:InvalidResource1 ;
+.
+ex:TestShape2
+  sh:path ex:property ;
+  sh:datatype xsd:integer ;
+  sh:severity sh:Info ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <severity-002>
+    ) ;
+.
+<severity-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:severity 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Info ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape2 ;
+          sh:value "true"^^xsd:boolean ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity ex:MySeverity ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape ex:TestShape1 ;
+          sh:value ex:InvalidResource1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/and-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/and-001.ttl
@@ -1,0 +1,77 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/and-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidRectangle1
+  rdf:type ex:Rectangle ;
+  ex:height 3 ;
+.
+ex:InvalidRectangle2
+  rdf:type ex:Rectangle ;
+  ex:width 2 ;
+.
+ex:Rectangle
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:and (
+      [
+        sh:property [
+            sh:path ex:width ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+      [
+        sh:property [
+            sh:path ex:height ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+    ) ;
+.
+ex:ValidRectangle1
+  rdf:type ex:Rectangle ;
+  ex:height 3 ;
+  ex:width 2 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <and-001>
+    ) ;
+.
+<and-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:and at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidRectangle1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:Rectangle ;
+          sh:value ex:InvalidRectangle1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidRectangle2 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:Rectangle ;
+          sh:value ex:InvalidRectangle2 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/and-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/and-002.ttl
@@ -1,0 +1,74 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/and-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:AndShape
+  rdf:type sh:NodeShape ;
+  sh:and (
+      ex:SuperShape
+      [
+        sh:property [
+            sh:path ex:property ;
+            sh:maxCount 1 ;
+          ] ;
+      ]
+    ) ;
+  sh:targetNode ex:InvalidInstance1 ;
+  sh:targetNode ex:InvalidInstance2 ;
+  sh:targetNode ex:ValidInstance1 ;
+.
+ex:InvalidInstance2
+  ex:property "One" ;
+  ex:property "Two" ;
+.
+ex:SuperShape
+  rdf:type sh:NodeShape ;
+  sh:property [
+      sh:path ex:property ;
+      sh:minCount 1 ;
+    ] ;
+.
+ex:ValidInstance1
+  ex:property "One" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <and-002>
+    ) ;
+.
+<and-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:and at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:AndShape ;
+          sh:value ex:InvalidInstance1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:AndShape ;
+          sh:value ex:InvalidInstance2 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/class-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/class-001.ttl
@@ -1,0 +1,70 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:John
+  rdf:type ex:MalePerson ;
+.
+ex:MalePerson
+  rdf:type rdfs:Class ;
+  rdfs:subClassOf ex:Person ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:Quokki
+  rdf:type ex:Animal ;
+.
+ex:Someone
+  rdf:type ex:Person ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:class ex:Person ;
+  sh:targetNode ex:John ;
+  sh:targetNode ex:Quokki ;
+  sh:targetNode ex:Someone ;
+  sh:targetNode ex:Typeless ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <class-001>
+    ) ;
+.
+<class-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:class at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Quokki ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Quokki ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Typeless ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Typeless ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/class-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/class-002.ttl
@@ -1,0 +1,62 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/class-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:NamedInstance
+  rdf:type ex:TestClass ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:class ex:TestClass ;
+  sh:targetClass ex:BNodeClass ;
+  sh:targetNode ex:NamedInstance ;
+  sh:targetNode "String" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <class-002>
+    ) ;
+.
+<class-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:class at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "String" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "String" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b9751 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b9751 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b9751
+  rdf:type ex:BNodeClass ;
+.
+[
+  rdf:type ex:BNodeClass ;
+  rdf:type ex:TestClass ;
+].

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/class-003.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/class-003.ttl
@@ -1,0 +1,105 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/class-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:John	# not Animal
+  rdf:type ex:MalePerson ;
+.
+ex:Joe # OK
+  rdf:type ex:MalePerson ;
+  rdf:type ex:Animal ;
+.
+ex:MalePerson
+  rdf:type rdfs:Class ;
+  rdfs:subClassOf ex:Person ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:Quokki # not Person
+  rdf:type ex:Animal ;
+.
+ex:Quokkip # not Animal
+  rdf:type ex:Person ;
+.
+ex:Someone # OK
+  rdf:type ex:Person ;
+  rdf:type ex:Animal ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:class ex:Person ;
+  sh:class ex:Animal ;
+  sh:targetClass ex:MalePerson ;
+  sh:targetNode ex:John ;
+  sh:targetNode ex:Quokki ;
+  sh:targetNode ex:Quokkip ;
+  sh:targetNode ex:Someone ;
+  sh:targetNode ex:Typeless ; # not Animal, not Person
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <class-003>
+    ) ;
+.
+<class-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:class at node shape 003 multiple classes, overlapping target sets" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Typeless ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Typeless ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Typeless ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Typeless ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Quokki ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Quokki ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:John ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:John ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Quokkip ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Quokkip ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/closed-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/closed-001.ttl
@@ -1,0 +1,64 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:SomeClass ;
+  ex:otherProperty 4 ;
+  ex:someProperty 3 ;
+.
+ex:MyShape
+  rdf:type sh:NodeShape ;
+  sh:closed "true"^^xsd:boolean ;
+  sh:property [
+      sh:path ex:someProperty ;
+    ] ;
+  sh:targetNode ex:InvalidInstance1 ;
+  sh:targetNode ex:ValidInstance1 ;
+.
+ex:ValidInstance1
+  ex:someProperty 3 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <closed-001>
+    ) ;
+.
+<closed-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:closed at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath rdf:type ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
+          sh:sourceShape ex:MyShape ;
+          sh:value ex:SomeClass ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:otherProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
+          sh:sourceShape ex:MyShape ;
+          sh:value 4 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/closed-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/closed-002.ttl
@@ -1,0 +1,58 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/closed-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  ex:otherProperty 4 ;
+  ex:someProperty 3 ;
+.
+ex:MyShape
+  rdf:type sh:NodeShape ;
+  sh:closed "true"^^xsd:boolean ;
+  sh:ignoredProperties (
+      rdf:type
+    ) ;
+  sh:property [
+      sh:path ex:someProperty ;
+    ] ;
+  sh:targetNode ex:InvalidInstance1 ;
+  sh:targetNode ex:ValidInstance1 ;
+.
+ex:ValidInstance1
+  rdf:type ex:SomeClass ;
+  ex:someProperty 3 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <closed-002>
+    ) ;
+.
+<closed-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:closed at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:otherProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent ;
+          sh:sourceShape ex:MyShape ;
+          sh:value 4 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/datatype-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/datatype-001.ttl
@@ -1,0 +1,64 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype xsd:integer ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode xsd:integer ;
+  sh:targetNode 42 ;
+  sh:targetNode "aldi"^^xsd:integer ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <datatype-001>
+    ) ;
+.
+<datatype-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:datatype at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode xsd:integer ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value xsd:integer ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "aldi"^^xsd:integer ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "aldi"^^xsd:integer ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b30507 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b30507 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b30507
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/datatype-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/datatype-002.ttl
@@ -1,0 +1,53 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/datatype-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:datatype rdf:langString ;
+  sh:targetNode "<span>Hello</span>"^^rdf:HTML ;
+  sh:targetNode "G'day"@en-AU ;
+  sh:targetNode "Hallo"@de ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <datatype-002>
+    ) ;
+.
+<datatype-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:datatype at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "<span>Hello</span>"^^rdf:HTML ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "<span>Hello</span>"^^rdf:HTML ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/disjoint-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/disjoint-001.ttl
@@ -1,0 +1,51 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/disjoint-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property ex:InvalidResource1 ;
+  ex:property ex:ValidResource1 ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:disjoint ex:property ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:ValidResource1
+  ex:property ex:InvalidResource1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <disjoint-001>
+    ) ;
+.
+<disjoint-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:disjoint at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DisjointConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/equals-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/equals-001.ttl
@@ -1,0 +1,59 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/equals-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property ex:InvalidResource1 ;
+  ex:property ex:SomeValue ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:equals ex:property ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:ValidResource1
+  ex:property ex:ValidResource1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <equals-001>
+    ) ;
+.
+<equals-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:equals at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:SomeValue ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource2 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/hasValue-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/hasValue-001.ttl
@@ -1,0 +1,44 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/hasValue-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:hasValue "Test" ;
+  sh:targetNode "Invalid String" ;
+  sh:targetNode "Test" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <hasValue-001>
+    ) ;
+.
+<hasValue-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:hasValue at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Invalid String" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:HasValueConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Invalid String" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/in-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/in-001.ttl
@@ -1,0 +1,63 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/in-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Green
+  rdf:type ex:TestShape ;
+  rdfs:label "Green" ;
+.
+ex:InvalidInstance
+  rdf:type ex:TestShape ;
+  rdfs:label "Invalid instance" ;
+.
+ex:Red
+  rdf:type ex:TestShape ;
+  rdfs:label "Red" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:in (
+      ex:Green
+      ex:Red
+      ex:Yellow
+    ) ;
+.
+ex:Yellow
+  rdf:type ex:TestShape ;
+  rdfs:label "Yellow" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <in-001>
+    ) ;
+.
+<in-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:in at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:InConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidInstance ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/languageIn-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/languageIn-001.ttl
@@ -1,0 +1,66 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/languageIn-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:languageIn (
+      "en"
+      "fr"
+    ) ;
+  sh:targetNode rdfs:Resource ;
+  sh:targetNode "Deutsch"@de ;
+  sh:targetNode "English"@en ;
+  sh:targetNode "Francais"@fr ;
+  sh:targetNode "Plain String" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <languageIn-001>
+    ) ;
+.
+<languageIn-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:languageIn at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode rdfs:Resource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LanguageInConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value rdfs:Resource ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Deutsch"@de ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LanguageInConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Deutsch"@de ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Plain String" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LanguageInConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Plain String" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/manifest.ttl
@@ -1,0 +1,40 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/node" ;
+	mf:include <and-001.ttl> ;
+	mf:include <and-002.ttl> ;
+	mf:include <class-001.ttl> ;
+	mf:include <class-002.ttl> ;
+	mf:include <class-003.ttl> ;
+	mf:include <closed-001.ttl> ;
+	mf:include <closed-002.ttl> ;
+	mf:include <datatype-001.ttl> ;
+	mf:include <datatype-002.ttl> ;
+	mf:include <disjoint-001.ttl> ;
+	mf:include <equals-001.ttl> ;
+	mf:include <hasValue-001.ttl> ;
+	mf:include <in-001.ttl> ;
+	mf:include <languageIn-001.ttl> ;
+	mf:include <maxExclusive-001.ttl> ;
+	mf:include <maxInclusive-001.ttl> ;
+	mf:include <maxLength-001.ttl> ;
+	mf:include <minExclusive-001.ttl> ;
+	mf:include <minInclusive-001.ttl> ;
+	mf:include <minInclusive-002.ttl> ;
+	mf:include <minInclusive-003.ttl> ;
+	mf:include <minLength-001.ttl> ;
+	mf:include <node-001.ttl> ;
+	mf:include <nodeKind-001.ttl> ;
+	mf:include <not-001.ttl> ;
+	mf:include <not-002.ttl> ;
+	mf:include <or-001.ttl> ;
+	mf:include <pattern-001.ttl> ;
+	mf:include <pattern-002.ttl> ;
+	mf:include <xone-001.ttl> ;
+	mf:include <xone-duplicate.ttl> ;
+	mf:include <qualified-001.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/maxExclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/maxExclusive-001.ttl
@@ -1,0 +1,91 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/maxExclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:maxExclusive 4 ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode ex:John ;
+  sh:targetNode 3.9 ;
+  sh:targetNode 4 ;
+  sh:targetNode 4.0 ;
+  sh:targetNode 4.1 ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxExclusive-001>
+    ) ;
+.
+<maxExclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxExclusive at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:John ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:John ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 4 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 4 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 4.0 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 4.0 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 4.1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 4.1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b11982 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b11982 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b11982
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/maxInclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/maxInclusive-001.ttl
@@ -1,0 +1,75 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/maxInclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:maxInclusive 4 ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode ex:John ;
+  sh:targetNode 3.9 ;
+  sh:targetNode 4 ;
+  sh:targetNode 4.0 ;
+  sh:targetNode 4.1 ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxInclusive-001>
+    ) ;
+.
+<maxInclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxInclusive at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:John ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:John ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 4.1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 4.1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b22005 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b22005 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b22005
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/maxLength-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/maxLength-001.ttl
@@ -1,0 +1,87 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/maxLength-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:maxLength 4 ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode <a:b> ;
+  sh:targetNode ex:John ;
+  sh:targetNode 123 ;
+  sh:targetNode 1234 ;
+  sh:targetNode 12345 ;
+  sh:targetNode "2017-03-29"^^xsd:date ;
+  sh:targetNode "Hel" ;
+  sh:targetNode "Hell" ;
+  sh:targetNode "Hell"@en ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxLength-001>
+    ) ;
+.
+<maxLength-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxLength at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:John ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:John ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 12345 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 12345 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "2017-03-29"^^xsd:date ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "2017-03-29"^^xsd:date ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b34236 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b34236 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b34236
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minExclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minExclusive-001.ttl
@@ -1,0 +1,91 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/minExclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:minExclusive 4 ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode ex:John ;
+  sh:targetNode 3.9 ;
+  sh:targetNode 4 ;
+  sh:targetNode 4.0 ;
+  sh:targetNode 4.1 ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minExclusive-001>
+    ) ;
+.
+<minExclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minExclusive at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:John ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:John ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 3.9 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 3.9 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 4 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 4 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 4.0 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 4.0 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hello" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hello" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b33079 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b33079 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b33079
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minInclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minInclusive-001.ttl
@@ -1,0 +1,44 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:minInclusive 8 ;
+  sh:targetNode 7 ;
+  sh:targetNode 8 ;
+  sh:targetNode 9 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minInclusive-001>
+    ) ;
+.
+<minInclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minInclusive at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 7 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 7 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minInclusive-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minInclusive-002.ttl
@@ -1,0 +1,61 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape a sh:NodeShape ;
+  sh:minInclusive "2002-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-10T12:00:01-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-09T12:00:00-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-10T12:00:00"^^xsd:dateTime ;
+  sh:targetNode ex:TestShape ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minInclusive-002>
+    ) ;
+.
+<minInclusive-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minInclusive at node shape 002 - dateTime with timezone" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "2002-10-10T12:00:00"^^xsd:dateTime ;
+          sh:value     "2002-10-10T12:00:00"^^xsd:dateTime ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "2002-10-09T12:00:00-05:00"^^xsd:dateTime ;
+          sh:value     "2002-10-09T12:00:00-05:00"^^xsd:dateTime ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:TestShape ;
+          sh:value     ex:TestShape ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minInclusive-003.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minInclusive-003.ttl
@@ -1,0 +1,70 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/minInclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:minInclusive "2002-10-10T12:00:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-10T12:00:01-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-09T12:00:00-05:00"^^xsd:dateTime ;
+  sh:targetNode "2002-10-10T12:00:00"^^xsd:dateTime ;
+  sh:targetNode ex:TestShape ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minInclusive-003>
+    ) ;
+.
+<minInclusive-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minInclusive at node shape 003 - dateTime without timezone" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "2002-10-10T12:00:00-05:00"^^xsd:dateTime ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "2002-10-10T12:00:00-05:00"^^xsd:dateTime ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "2002-10-10T12:00:01-05:00"^^xsd:dateTime ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "2002-10-10T12:00:01-05:00"^^xsd:dateTime ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "2002-10-09T12:00:00-05:00"^^xsd:dateTime ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "2002-10-09T12:00:00-05:00"^^xsd:dateTime ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:TestShape ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minLength-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/minLength-001.ttl
@@ -1,0 +1,79 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/minLength-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:minLength 4 ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode <a:b> ;
+  sh:targetNode ex:John ;
+  sh:targetNode 123 ;
+  sh:targetNode 1234 ;
+  sh:targetNode 12345 ;
+  sh:targetNode "2017-03-29"^^xsd:date ;
+  sh:targetNode "Hel" ;
+  sh:targetNode "Hell" ;
+  sh:targetNode "Hell"@en ;
+  sh:targetNode "Hello" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minLength-001>
+    ) ;
+.
+<minLength-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minLength at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode <a:b> ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value <a:b> ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 123 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 123 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hel" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hel" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b19019 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b19019 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b19019
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/node-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/node-001.ttl
@@ -1,0 +1,55 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/node-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance
+  rdf:type ex:TestClass ;
+  rdfs:label "Invalid instance" ;
+.
+ex:TestClass
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test class" ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:node [
+      sh:class ex:OtherClass ;
+    ] ;
+.
+ex:ValidInstance
+  rdf:type ex:OtherClass ;
+  rdf:type ex:TestClass ;
+  rdfs:label "Valid instance" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <node-001>
+    ) ;
+.
+<node-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:node at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+          sh:sourceShape ex:TestClass ;
+          sh:value ex:InvalidInstance ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/nodeKind-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/nodeKind-001.ttl
@@ -1,0 +1,43 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/nodeKind-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:IRITestShape
+  rdf:type sh:NodeShape ;
+  sh:nodeKind sh:IRI ;
+  sh:targetNode ex:John ;
+  sh:targetNode "true"^^xsd:boolean ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <nodeKind-001>
+    ) ;
+.
+<nodeKind-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:nodeKind at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "true"^^xsd:boolean ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape ex:IRITestShape ;
+          sh:value "true"^^xsd:boolean ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/not-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/not-001.ttl
@@ -1,0 +1,59 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/not-001#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  ex:property "some value" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:not [
+      rdf:type sh:NodeShape ;
+      sh:property [
+          sh:path ex:property ;
+          sh:minCount 1 ;
+        ] ;
+    ] ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <not-001>
+    ) ;
+.
+<not-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:not at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NotConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/not-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/not-002.ttl
@@ -1,0 +1,52 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/not-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  ex:property "Some value" ;
+.
+ex:NotExampleShape
+  rdf:type sh:NodeShape ;
+  sh:not [
+      rdf:type sh:NodeShape ;
+      sh:property [
+          sh:path ex:property ;
+          sh:minCount 1 ;
+        ] ;
+    ] ;
+  sh:targetNode ex:InvalidInstance1 ;
+  sh:targetNode ex:ValidInstance1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <not-002>
+    ) ;
+.
+<not-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:not at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NotConstraintComponent ;
+          sh:sourceShape ex:NotExampleShape ;
+          sh:value ex:InvalidInstance1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/or-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/or-001.ttl
@@ -1,0 +1,91 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/or-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidRectangle1
+  rdf:type ex:RectangleWithArea ;
+  ex:height 3 ;
+.
+ex:InvalidRectangle2
+  rdf:type ex:RectangleWithArea ;
+.
+ex:RectangleWithArea
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:or (
+      [
+        sh:property [
+            sh:path ex:height ;
+            sh:minCount 1 ;
+          ] ;
+        sh:property [
+            sh:path ex:width ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+      [
+        sh:property [
+            sh:path ex:area ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+    ) ;
+.
+ex:ValidRectangle1
+  rdf:type ex:RectangleWithArea ;
+  ex:height 3 ;
+  ex:width 2 ;
+.
+ex:ValidRectangle2
+  rdf:type ex:RectangleWithArea ;
+  ex:area 6 ;
+  ex:height 3 ;
+  ex:width 2 ;
+.
+ex:ValidRectangle3
+  rdf:type ex:RectangleWithArea ;
+  ex:area 6 ;
+  ex:height 3 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <or-001>
+    ) ;
+.
+<or-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:or at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidRectangle1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:RectangleWithArea ;
+          sh:value ex:InvalidRectangle1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidRectangle2 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:RectangleWithArea ;
+          sh:value ex:InvalidRectangle2 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/pattern-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/pattern-001.ttl
@@ -1,0 +1,76 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:pattern "^[2-8][0-9]*$" ;
+  sh:targetClass ex:TestClass ;
+  sh:targetNode ex:Test ;
+  sh:targetNode 20000123 ;
+  sh:targetNode "3456" ;
+  sh:targetNode 39 ;
+  sh:targetNode "777777"@mi ;
+  sh:targetNode 9 ;
+  sh:targetNode "John" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pattern-001>
+    ) ;
+.
+<pattern-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:pattern at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Test ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:Test ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode 9 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value 9 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "John" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "John" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode _:b22415 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value _:b22415 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b22415
+  rdf:type ex:TestClass ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/pattern-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/pattern-002.ttl
@@ -1,0 +1,45 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/pattern-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:flags "i" ;
+  sh:pattern "Aldi" ;
+  sh:targetNode "Aldi" ;
+  sh:targetNode "Alti" ;
+  sh:targetNode "aLdI" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pattern-002>
+    ) ;
+.
+<pattern-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:pattern at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Alti" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Alti" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/qualified-001-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/qualified-001-data.ttl
@@ -1,0 +1,4 @@
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:i a ex:C1 .
+ex:j a ex:C1 , ex:C2 .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/qualified-001-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/qualified-001-shapes.ttl
@@ -1,0 +1,10 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:s1 a sh:NodeShape ;
+  sh:targetClass ex:C1 ;
+  sh:class ex:C2 ;
+  sh:qualifiedValueShapesDisjoint "1"^^xsd:boolean ;
+  sh:qualifiedMinCount 5 ;
+  sh:qualifiedMaxCount 2 .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/qualified-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/qualified-001.ttl
@@ -1,0 +1,28 @@
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix ex: <http://example.org/shacl-test/> .
+
+<> a mf:Manifest ;
+  mf:entries (
+      <qualified-001>
+    ) .
+
+<qualified-001> a sht:Validate;
+  rdfs:label "Test of qualified parameters allowed in node shapes" ;
+  mf:action [ sht:dataGraph <qualified-001-data.ttl> ;
+              sht:shapesGraph <qualified-001-shapes.ttl> ] ;
+  mf:result [ rdf:type sh:ValidationReport ;
+              sh:conforms "false"^^xsd:boolean ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value ex:i ;
+ 			  sh:sourceShape ex:s1 ;
+ 			  sh:sourceConstraintComponent sh:ClassConstraintComponent ] ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-001.ttl
@@ -1,0 +1,74 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/node/xone-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Bob
+  rdf:type ex:Person ;
+  ex:firstName "Robert" ;
+  ex:lastName "Coin" ;
+.
+ex:Carla
+  rdf:type ex:Person ;
+  ex:fullName "Carla Miller" ;
+.
+ex:Dory
+  rdf:type ex:Person ;
+  ex:firstName "Dory" ;
+  ex:fullName "Dory Dunce" ;
+  ex:lastName "Dunce" ;
+.
+ex:XoneConstraintExampleShape
+  rdf:type sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:xone (
+      [
+        sh:property [
+            sh:path ex:fullName ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+      [
+        sh:property [
+            sh:path ex:firstName ;
+            sh:minCount 1 ;
+          ] ;
+        sh:property [
+            sh:path ex:lastName ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+    ) ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <xone-001>
+    ) ;
+.
+<xone-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:xone at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Dory ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:XoneConstraintComponent ;
+          sh:sourceShape ex:XoneConstraintExampleShape ;
+          sh:value ex:Dory ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-duplicate-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-duplicate-data.ttl
@@ -1,0 +1,4 @@
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:i a ex:C1 .
+ex:j a ex:C1 , ex:C2 .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-duplicate-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-duplicate-shapes.ttl
@@ -1,0 +1,7 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:s1 a sh:NodeShape ;
+  sh:targetClass ex:C1 ;
+  sh:xone ( ex:s2 ex:s2 ) .
+ex:s2 sh:class ex:C2 .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-duplicate.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/node/xone-duplicate.ttl
@@ -1,0 +1,34 @@
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix ex: <http://example.org/shacl-test/> .
+
+<> a mf:Manifest ;
+  mf:entries (
+      <xone-duplicate>
+    ) .
+
+<xone-duplicate> a sht:Validate;
+  rdfs:label "Test of validation report for shape xone-duplicate by property constraints" ;
+  mf:action [ sht:dataGraph <xone-duplicate-data.ttl> ;
+              sht:shapesGraph <xone-duplicate-shapes.ttl> ] ;
+  mf:result [ rdf:type sh:ValidationReport ;
+              sh:conforms "false"^^xsd:boolean ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value ex:i ;
+ 			  sh:sourceShape ex:s1 ;
+ 			  sh:sourceConstraintComponent sh:XoneConstraintComponent ] ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:j ;
+ 			  sh:value ex:j ;
+ 			  sh:sourceShape ex:s1 ;
+ 			  sh:sourceConstraintComponent sh:XoneConstraintComponent ] ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/manifest.ttl
@@ -1,0 +1,21 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/path" ;
+	mf:include <path-alternative-001.ttl> ;
+	mf:include <path-complex-001.ttl> ;
+	mf:include <path-complex-002.ttl> ;
+	mf:include <path-inverse-001.ttl> ;
+	mf:include <path-oneOrMore-001.ttl> ;
+	mf:include <path-sequence-001.ttl> ;
+	mf:include <path-sequence-002.ttl> ;
+	mf:include <path-sequence-duplicate-001.ttl> ;
+	mf:include <path-strange-001.ttl> ;
+	mf:include <path-strange-002.ttl> ;
+	mf:include <path-zeroOrMore-001.ttl> ;
+	mf:include <path-zeroOrOne-001.ttl> ;
+	mf:include <path-unused-001.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-alternative-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-alternative-001.ttl
@@ -1,0 +1,86 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-alternative-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 "One" ;
+  ex:property3 "Three" ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path [
+      sh:alternativePath (
+          ex:property1
+          ex:property2
+        ) ;
+    ] ;
+  sh:minCount 2 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+  sh:targetNode ex:ValidResource3 ;
+.
+ex:ValidResource1
+  ex:property1 "One" ;
+  ex:property1 "Two" ;
+.
+ex:ValidResource2
+  ex:property1 "One" ;
+  ex:property2 "Two" ;
+.
+ex:ValidResource3
+  ex:property2 "One" ;
+  ex:property2 "Two" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-alternative-001>
+    ) ;
+.
+<path-alternative-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sh:alternativePath 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath [
+              sh:alternativePath (
+                  ex:property1
+                  ex:property2
+                ) ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath [
+              sh:alternativePath (
+                  ex:property1
+                  ex:property2
+                ) ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-001.ttl
@@ -1,0 +1,91 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource
+  rdf:type ex:Animal ;
+  rdfs:label "Invalid" ;
+.
+ex:MalePerson
+  rdf:type rdfs:Class ;
+  rdfs:subClassOf ex:Person ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path (
+      rdf:type
+      [
+        sh:zeroOrMorePath rdfs:subClassOf ;
+      ]
+    ) ;
+  sh:hasValue ex:Person ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+  sh:targetNode ex:ValidResource3 ;
+.
+ex:ValidResource1
+  rdf:type ex:Person ;
+.
+ex:ValidResource2
+  rdf:type ex:MalePerson ;
+.
+ex:ValidResource3
+  rdf:type ex:Animal ;
+  rdf:type ex:MalePerson ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-complex-001>
+    ) ;
+.
+<path-complex-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path complex (rdf:type/rdfs:subClassOf*) 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath (
+              rdf:type
+              [
+                sh:zeroOrMorePath rdfs:subClassOf ;
+              ]
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:HasValueConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath (
+              rdf:type
+              [
+                sh:zeroOrMorePath rdfs:subClassOf ;
+              ]
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:HasValueConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-002-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-002-data.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.org/shacl/tests/> .
+
+ex:j ex:p ex:i .
+
+ex:k ex:p ex:j .
+
+ex:l ex:p ex:j .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-002-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-002-shapes.ttl
@@ -1,0 +1,14 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl/tests/> .
+
+ex:s1 a sh:PropertyShape ;
+ sh:targetNode ex:i ;
+ sh:path ( _:pinv _:pinv ) ;
+ sh:class ex:C .
+
+_:pinv sh:inversePath ex:p .
+
+ex:s2 a sh:PropertyShape ;
+ sh:targetNode ex:i ;
+ sh:path ( [ sh:inversePath ex:p ] [ sh:inversePath ex:p ] ) ;
+ sh:class ex:C .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-complex-002.ttl
@@ -1,0 +1,51 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.org/shacl/tests/> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a mf:Manifest ;
+  mf:entries (
+      <path-complex-002>
+    ) .
+
+<path-complex-002> a sht:Validate ;
+  rdfs:label "Test of complex path validation results" ;
+  mf:action [
+      sht:dataGraph <path-complex-002-data.ttl> ;
+      sht:shapesGraph <path-complex-002-shapes.ttl> ] ;
+  mf:result [ a sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:i ;
+	  sh:value ex:k ;
+          sh:resultPath ( [ sh:inversePath ex:p ] [ sh:inversePath ex:p ] ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:s1 ] ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:i ;
+	  sh:value ex:l ;
+          sh:resultPath ( [ sh:inversePath ex:p ] [ sh:inversePath ex:p ] ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:s1 ] ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:i ;
+	  sh:value ex:l ;
+          sh:resultPath ( [ sh:inversePath ex:p ] [ sh:inversePath ex:p ] ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:s2 ] ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:i ;
+	  sh:value ex:k ;
+          sh:resultPath( [ sh:inversePath ex:p ] [ sh:inversePath ex:p ] ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:s2 ] ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-inverse-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-inverse-001.ttl
@@ -1,0 +1,90 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-inverse-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type ex:Person ;
+.
+ex:InvalidResource2
+  rdf:type ex:Person ;
+.
+ex:Parent1
+  ex:child ex:InvalidResource1 ;
+  ex:child ex:InvalidResource2 ;
+  ex:child ex:ValidResource1 ;
+.
+ex:Parent2
+  ex:child ex:InvalidResource2 ;
+  ex:child ex:ValidResource1 ;
+.
+ex:Parent3
+  ex:child ex:InvalidResource2 ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Person" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-P ;
+  sh:targetClass ex:Person ;
+.
+ex:TestShape-P
+  rdf:type sh:PropertyShape ;
+  sh:path [
+      sh:inversePath ex:child ;
+    ] ;
+  sh:maxCount 2 ;
+  sh:minCount 2 ;
+.
+ex:ValidResource1
+  rdf:type ex:Person ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-inverse-001>
+    ) ;
+.
+<path-inverse-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sh:inversePath 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath [
+              sh:inversePath ex:child ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-P ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath [
+              sh:inversePath ex:child ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-P ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-oneOrMore-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-oneOrMore-001.ttl
@@ -1,0 +1,71 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-oneOrMore-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+.
+ex:InvalidResource2
+  ex:child ex:Person2 ;
+.
+ex:Person1
+  ex:child ex:Person2 ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path [
+      sh:oneOrMorePath ex:child ;
+    ] ;
+  sh:minCount 2 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:ValidResource1
+  ex:child ex:Person1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-oneOrMore-001>
+    ) ;
+.
+<path-oneOrMore-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sh:oneOrMorePath 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath [
+              sh:oneOrMorePath ex:child ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath [
+              sh:oneOrMorePath ex:child ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-sequence-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-sequence-001.ttl
@@ -1,0 +1,80 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 ex:Node3 ;
+  ex:property2 ex:Node4 ;
+.
+ex:Node1
+  ex:property2 "One" ;
+.
+ex:Node2
+  ex:property2 "Two" ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path (
+      ex:property1
+      ex:property2
+    ) ;
+  sh:minCount 1 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:ValidResource1
+  ex:property1 ex:Node1 ;
+.
+ex:ValidResource2
+  ex:property1 ex:Node1 ;
+  ex:property1 ex:Node2 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-sequence-001>
+    ) ;
+.
+<path-sequence-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sequence 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath (
+              ex:property1
+              ex:property2
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath (
+              ex:property1
+              ex:property2
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-sequence-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-sequence-002.ttl
@@ -1,0 +1,83 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 ex:Node3 ;
+  ex:property2 ex:Node4 ;
+.
+ex:Node1
+  ex:property2 ex:Node2 ;
+.
+ex:Node2
+  ex:property3 "Value" ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path (
+      ex:property1
+      ex:property2
+      ex:property3
+    ) ;
+  sh:minCount 1 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:ValidResource1
+  ex:property1 ex:Node1 ;
+.
+ex:ValidResource2
+  ex:property1 ex:Node1 ;
+  ex:property1 ex:Node2 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-sequence-002>
+    ) ;
+.
+<path-sequence-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sequence 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath (
+              ex:property1
+              ex:property2
+              ex:property3
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath (
+              ex:property1
+              ex:property2
+              ex:property3
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-sequence-duplicate-001.ttl
@@ -1,0 +1,63 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-sequence-duplicate-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:A
+  ex:p1 [
+      ex:p2 "value" ;
+    ] ;
+  ex:p1 [
+      ex:p2 "value" ;
+    ] ;
+.
+ex:S
+  rdf:type sh:NodeShape ;
+  sh:property ex:SP ;
+  sh:targetNode ex:A ;
+.
+ex:SP
+  rdf:type sh:PropertyShape ;
+  sh:path (
+      ex:p1
+      ex:p2
+    ) ;
+  sh:maxCount 1 ;
+  sh:nodeKind sh:IRI ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-sequence-duplicate-001>
+    ) ;
+.
+<path-sequence-duplicate-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sequence with duplicate 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:A ;
+          sh:resultPath (
+              ex:p1
+              ex:p2
+            ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape ex:SP ;
+          sh:value "value" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-strange-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-strange-001.ttl
@@ -1,0 +1,52 @@
+@prefix ex: <http://example.org/test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:i a ex:C ;
+  ex:p ex:ip .
+ex:ip ex:q ex:ipq .
+ex:ipq a ex:C .
+ex:pi ex:p ex:i .
+
+ex:j a ex:C ;
+  ex:p ex:jp .
+ex:jp ex:q ex:jpq .
+
+ex:s1 a sh:PropertyShape ;
+  sh:targetClass ex:C ;
+  sh:path [ rdf:first ex:p ; rdf:rest [ rdf:first ex:q ; rdf:rest rdf:nil ] ;
+  	    sh:inversePath ex:p ] ;
+  sh:class ex:C .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-strange-001>
+    ) ;
+.
+
+<path-strange-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of strange path 001 two valid paths together" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:j ;
+          sh:value ex:jpq ;
+          sh:resultPath ( ex:p ex:q ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:s1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-strange-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-strange-002.ttl
@@ -1,0 +1,52 @@
+@prefix ex: <http://example.org/test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:i a ex:C ;
+  ex:p ex:ip .
+ex:ip ex:q ex:ipq .
+ex:ipq a ex:C .
+ex:pi ex:p ex:i .
+
+ex:j a ex:C ;
+  ex:p ex:jp .
+ex:jp ex:q ex:jpq .
+
+ex:s1 a sh:PropertyShape ;
+  sh:targetClass ex:C ;
+  sh:path [ rdf:first ex:p ; rdf:rest [ rdf:first ex:q ; rdf:rest rdf:nil ] ;
+  	    sh:inversePath ( ex:p ) ] ;
+  sh:class ex:C .
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-strange-002>
+    ) ;
+.
+
+<path-strange-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of strange path 002 valid and invalid paths together" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:j ;
+          sh:value ex:jpq ;
+          sh:resultPath ( ex:p ex:q ) ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:s1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-unused-001-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-unused-001-data.ttl
@@ -1,0 +1,5 @@
+@prefix ex: <http://example.org/shacl/tests/> .
+
+ex:i a ex:C .
+
+ex:j a ex:D .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-unused-001-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-unused-001-shapes.ttl
@@ -1,0 +1,18 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl/tests/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:s1 a sh:NodeShape ;
+ sh:targetNode ex:j, ex:i ;
+ sh:class ex:C .
+
+_:p1 sh:inversePath _:p2 .
+
+_:p2 sh:zeroOrMorePath ( _:p2 ) .
+
+_:p2 sh:zeroOrOnePath [ rdf:rest rdf:nil ] .
+
+_:p3 sh:alternativePath ( ex:p ) ;
+  rdfs:comment "invalid path" .
+

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-unused-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-unused-001.ttl
@@ -1,0 +1,29 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://example.org/shacl/tests/> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a mf:Manifest ;
+  mf:entries (
+      <path-unused-001>
+    ) .
+
+<path-unused-001> a sht:Validate ;
+  rdfs:label "Test with unused ill-formed path" ;
+  mf:action [
+      sht:dataGraph <path-unused-001-data.ttl> ;
+      sht:shapesGraph <path-unused-001-shapes.ttl> ] ;
+  mf:result [ a sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [ a sh:ValidationResult ;
+          sh:focusNode ex:j ;
+	  sh:value ex:j ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceShape ex:s1 ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ] ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-zeroOrMore-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-zeroOrMore-001.ttl
@@ -1,0 +1,61 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrMore-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+.
+ex:Person2
+  ex:child ex:Person3 ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path [
+      sh:zeroOrMorePath ex:child ;
+    ] ;
+  sh:minCount 2 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:ValidResource1
+  ex:child ex:Person1 ;
+.
+ex:ValidResource2
+  ex:child ex:Person2 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-zeroOrMore-001>
+    ) ;
+.
+<path-zeroOrMore-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sh:zeroOrMorePath 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath [
+              sh:zeroOrMorePath ex:child ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-zeroOrOne-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/path/path-zeroOrOne-001.ttl
@@ -1,0 +1,61 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-zeroOrOne-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+.
+ex:Person2
+  ex:child ex:Person3 ;
+.
+ex:TestShape
+  rdf:type sh:PropertyShape ;
+  sh:path [
+      sh:zeroOrOnePath ex:child ;
+    ] ;
+  sh:minCount 2 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:ValidResource1
+  ex:child ex:Person1 ;
+.
+ex:ValidResource2
+  ex:child ex:Person2 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <path-zeroOrOne-001>
+    ) ;
+.
+<path-zeroOrOne-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of path sh:zeroOrOnePath 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath [
+              sh:zeroOrOnePath ex:child ;
+            ] ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/and-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/and-001.ttl
@@ -1,0 +1,107 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/and-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:AddressShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Address shape" ;
+  sh:property ex:AddressShape-address ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:InvalidResource3 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:AddressShape-address
+  sh:path ex:address ;
+  sh:and (
+      [
+        sh:property [
+            sh:path ex:suburb ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+      [
+        sh:property [
+            sh:path ex:postalCode ;
+            sh:minCount 1 ;
+          ] ;
+      ]
+    ) ;
+.
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  ex:address _:b61065 ;
+.
+ex:InvalidResource2
+  rdf:type rdfs:Resource ;
+  ex:address _:b31477 ;
+.
+ex:InvalidResource3
+  rdf:type rdfs:Resource ;
+  ex:address _:b94057 ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+  ex:address [
+      ex:postalCode 4879 ;
+      ex:suburb ex:KewarraBeach ;
+    ] ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <and-001>
+    ) ;
+.
+<and-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:and at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:address ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:AddressShape-address ;
+          sh:value _:b61065 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:address ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:AddressShape-address ;
+          sh:value _:b31477 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource3 ;
+          sh:resultPath ex:address ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:AndConstraintComponent ;
+          sh:sourceShape ex:AddressShape-address ;
+          sh:value _:b94057 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b31477
+  ex:suburb ex:KewarraBeach ;
+.
+_:b61065
+  ex:postalCode 4879 ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/class-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/class-001.ttl
@@ -1,0 +1,91 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/class-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  ex:testProperty ex:InvalidResource1 ;
+  ex:testProperty "A string" ;
+.
+ex:SubClass
+  rdf:type rdfs:Class ;
+  rdfs:subClassOf ex:SuperClass ;
+.
+ex:SubClassInstance
+  rdf:type ex:SubClass ;
+.
+ex:SuperClass
+  rdf:type rdfs:Class ;
+.
+ex:SuperClassInstance
+  rdf:type ex:SuperClass ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-testProperty ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  rdfs:label "test property" ;
+  sh:class ex:SuperClass ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+  ex:testProperty ex:SubClassInstance ;
+  ex:testProperty ex:SuperClassInstance ;
+.
+ex:ValidResource2
+  rdf:type rdfs:Resource ;
+  ex:testProperty [
+      rdf:type ex:SubClass ;
+    ] ;
+  ex:testProperty [
+      rdf:type ex:SuperClass ;
+    ] ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <class-001>
+    ) ;
+.
+<class-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:class at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value ex:InvalidResource1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value "A string" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-001.ttl
@@ -1,0 +1,76 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type ex:TestShape ;
+  ex:dateProperty "2011-01-01"^^xsd:dateTime ;
+  ex:integerProperty 11.1 ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-dateProperty ;
+  sh:property ex:TestShape-integerProperty ;
+.
+ex:TestShape-dateProperty
+  sh:path ex:dateProperty ;
+  rdfs:label "date property" ;
+  sh:datatype xsd:date ;
+.
+ex:TestShape-integerProperty
+  sh:path ex:integerProperty ;
+  rdfs:label "integer property" ;
+  sh:datatype xsd:integer ;
+.
+ex:ValidResource
+  rdf:type ex:TestShape ;
+  ex:dateProperty "2014-09-01"^^xsd:date ;
+  ex:integerProperty 0 ;
+  ex:integerProperty 1234 ;
+  rdfs:label "Valid resource" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <datatype-001>
+    ) ;
+.
+<datatype-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:datatype at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:dateProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape-dateProperty ;
+          sh:value "2011-01-01"^^xsd:dateTime ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:integerProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape-integerProperty ;
+          sh:value 11.1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-002.ttl
@@ -1,0 +1,71 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  ex:value "A"@en ;
+.
+ex:InvalidInstance2
+  ex:value 42 ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-value ;
+  sh:targetNode ex:InvalidInstance1 ;
+  sh:targetNode ex:InvalidInstance2 ;
+  sh:targetNode ex:ValidInstance1 ;
+  sh:targetNode ex:ValidInstance2 ;
+.
+ex:TestShape-value
+  sh:path ex:value ;
+  sh:datatype xsd:string ;
+.
+ex:ValidInstance1
+  ex:value "A" ;
+.
+ex:ValidInstance2
+  ex:value "A" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <datatype-002>
+    ) ;
+.
+<datatype-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:datatype at property shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:value ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape-value ;
+          sh:value "A"@en ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:value ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape-value ;
+          sh:value 42 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-003.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-003.ttl
@@ -1,0 +1,69 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/datatype-003.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  ex:value 42 ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-value ;
+  sh:targetNode ex:InvalidInstance1 ;
+  sh:targetNode ex:ValidInstance1 ;
+  sh:targetNode ex:ValidInstance2 ;
+  sh:targetNode ex:ValidInstance3 ;
+.
+ex:TestShape-value
+  sh:path ex:value ;
+  sh:or (
+      [
+        sh:datatype xsd:string ;
+      ]
+      [
+        sh:datatype rdf:langString ;
+      ]
+    ) ;
+.
+ex:ValidInstance1
+  ex:value "A" ;
+.
+ex:ValidInstance2
+  ex:value "A" ;
+.
+ex:ValidInstance3
+  ex:value "A"@en ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <datatype-003>
+    ) ;
+.
+<datatype-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:datatype at property shape 003" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:value ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:TestShape-value ;
+          sh:value 42 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-ill-formed-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-ill-formed-data.ttl
@@ -1,0 +1,6 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:i ex:p "300"^^xsd:byte .
+ex:i ex:p "55"^^xsd:integer .
+ex:i ex:p "c"^^xsd:byte .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-ill-formed-shapes.ttl
@@ -1,0 +1,8 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:s a sh:PropertyShape ;
+  sh:targetNode ex:i ;
+  sh:path ex:p ;
+  sh:datatype xsd:byte .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-ill-formed.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/datatype-ill-formed.ttl
@@ -1,0 +1,43 @@
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix ex: <http://example.org/shacl-test/> .
+
+<> rdf:type mf:Manifest ;
+   mf:entries (
+      <datatype-ill-formed>
+    ) .
+
+<datatype-ill-formed> rdf:type sht:Validate;
+  rdfs:label "Test of validation report for ill-formed literals" ;
+  mf:action [ sht:dataGraph <datatype-ill-formed-data.ttl> ;
+              sht:shapesGraph <datatype-ill-formed-shapes.ttl> ] ;
+  mf:result [ rdf:type sh:ValidationReport ;
+              sh:conforms "false"^^xsd:boolean ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value "300"^^xsd:byte ;
+			  sh:resultPath ex:p ;
+ 			  sh:sourceShape ex:s ;
+ 			  sh:sourceConstraintComponent sh:DatatypeConstraintComponent ] ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value "c"^^xsd:byte ;
+			  sh:resultPath ex:p ;
+ 			  sh:sourceShape ex:s ;
+ 			  sh:sourceConstraintComponent sh:DatatypeConstraintComponent ] ;
+	      sh:result [ rdf:type sh:ValidationResult ;
+ 	      		  sh:resultSeverity sh:Violation ;
+ 			  sh:focusNode ex:i ;
+ 			  sh:value "55"^^xsd:integer ;
+			  sh:resultPath ex:p ;
+ 			  sh:sourceShape ex:s ;
+ 			  sh:sourceConstraintComponent sh:DatatypeConstraintComponent ] ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/disjoint-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/disjoint-001.ttl
@@ -1,0 +1,84 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/disjoint-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 "A" ;
+  ex:property2 "A" ;
+.
+ex:InvalidResource2
+  ex:property1 "A" ;
+  ex:property1 "B" ;
+  ex:property2 "A" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-property1
+  sh:path ex:property1 ;
+  sh:disjoint ex:property2 ;
+.
+ex:ValidResource1
+  ex:property1 "A" ;
+  ex:property2 "B" ;
+.
+ex:ValidResource2
+  ex:property1 "A" ;
+  ex:property1 "B" ;
+  ex:property2 "C" ;
+  ex:property2 "D" ;
+.
+ex:property1
+  rdf:type rdf:Property ;
+.
+ex:property2
+  rdf:type rdf:Property ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <disjoint-001>
+    ) ;
+.
+<disjoint-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:disjoint at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DisjointConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "A" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DisjointConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "A" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/equals-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/equals-001.ttl
@@ -1,0 +1,119 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/equals-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 "A" ;
+  ex:property2 "B" ;
+.
+ex:InvalidResource2
+  ex:property1 "A" ;
+.
+ex:InvalidResource3
+  ex:property2 "A" ;
+.
+ex:InvalidResource4
+  ex:property1 "A" ;
+  ex:property1 "B" ;
+  ex:property2 "A" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:InvalidResource3 ;
+  sh:targetNode ex:InvalidResource4 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-property1
+  sh:path ex:property1 ;
+  sh:equals ex:property2 ;
+.
+ex:ValidResource1
+  ex:property1 "A" ;
+  ex:property2 "A" ;
+.
+ex:ValidResource2
+  ex:property1 "A" ;
+  ex:property1 "B" ;
+  ex:property2 "A" ;
+  ex:property2 "B" ;
+.
+ex:property1
+  rdf:type rdf:Property ;
+.
+ex:property2
+  rdf:type rdf:Property ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <equals-001>
+    ) ;
+.
+<equals-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:equals at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "A" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "B" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "A" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource3 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "A" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource4 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:EqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value "B" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/hasValue-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/hasValue-001.ttl
@@ -1,0 +1,68 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/hasValue-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidMalePerson
+  rdf:type ex:MalePerson ;
+  ex:gender "female" ;
+  rdfs:label "Invalid male person" ;
+.
+ex:MalePerson
+  rdf:type rdfs:Class ;
+  rdfs:label "Male person" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:PersonShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Person shape" ;
+  sh:property ex:PersonShape-gender ;
+  sh:targetClass ex:MalePerson ;
+.
+ex:PersonShape-gender
+  sh:path ex:gender ;
+  rdfs:label "gender" ;
+  sh:datatype xsd:string ;
+  sh:hasValue "male" ;
+.
+ex:ValidMalePerson1
+  rdf:type ex:MalePerson ;
+  ex:gender "male" ;
+.
+ex:ValidMalePerson2
+  rdf:type ex:MalePerson ;
+  ex:gender "female" ;
+  ex:gender "male" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <hasValue-001>
+    ) ;
+.
+<hasValue-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:hasValue at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidMalePerson ;
+          sh:resultPath ex:gender ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:HasValueConstraintComponent ;
+          sh:sourceShape ex:PersonShape-gender ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/in-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/in-001.ttl
@@ -1,0 +1,69 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/in-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:ShapeClass ;
+  ex:property "D" ;
+  rdfs:label "Invalid instance1" ;
+.
+ex:ShapeClass
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  sh:property ex:ShapeClass-property ;
+.
+ex:ShapeClass-property
+  sh:path ex:property ;
+  sh:datatype xsd:string ;
+  sh:in (
+      "A"
+      "B"
+      "C"
+    ) ;
+.
+ex:ValidInstance1
+  rdf:type ex:ShapeClass ;
+  ex:property "A" ;
+  rdfs:label "Valid instance1" ;
+.
+ex:ValidInstance2
+  rdf:type ex:ShapeClass ;
+  ex:property "A" ;
+  ex:property "B" ;
+  ex:property "C" ;
+  rdfs:label "Valid instance2" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <in-001>
+    ) ;
+.
+<in-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:in at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:InConstraintComponent ;
+          sh:sourceShape ex:ShapeClass-property ;
+          sh:value "D" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/languageIn-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/languageIn-001.ttl
@@ -1,0 +1,79 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/languageIn-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Berg
+  ex:prefLabel ex:BergLabel ;
+  ex:prefLabel "Berg" ;
+  ex:prefLabel "Berg"@de ;
+.
+ex:Mountain
+  ex:prefLabel "Hill"@en-NZ ;
+  ex:prefLabel "Maunga"@mi ;
+  ex:prefLabel "Mountain"@en ;
+.
+ex:NewZealandLanguagesShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:NewZealandLanguagesShape-prefLabel ;
+  sh:targetNode ex:Berg ;
+  sh:targetNode ex:Mountain ;
+.
+ex:NewZealandLanguagesShape-prefLabel
+  sh:path ex:prefLabel ;
+  sh:languageIn (
+      "en"
+      "mi"
+    ) ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <languageIn-001>
+    ) ;
+.
+<languageIn-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:languageIn at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Berg ;
+          sh:resultPath ex:prefLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LanguageInConstraintComponent ;
+          sh:sourceShape ex:NewZealandLanguagesShape-prefLabel ;
+          sh:value ex:BergLabel ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Berg ;
+          sh:resultPath ex:prefLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LanguageInConstraintComponent ;
+          sh:sourceShape ex:NewZealandLanguagesShape-prefLabel ;
+          sh:value "Berg" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Berg ;
+          sh:resultPath ex:prefLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LanguageInConstraintComponent ;
+          sh:sourceShape ex:NewZealandLanguagesShape-prefLabel ;
+          sh:value "Berg"@de ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/lessThan-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/lessThan-001.ttl
@@ -1,0 +1,96 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 4 ;
+  ex:property2 4 ;
+.
+ex:InvalidResource2
+  ex:property1 4 ;
+  ex:property1 6 ;
+  ex:property2 5 ;
+.
+ex:InvalidResource3
+  ex:property1 5 ;
+  ex:property2 4 ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:InvalidResource3 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-property1
+  sh:path ex:property1 ;
+  sh:lessThan ex:property2 ;
+.
+ex:ValidResource1
+  ex:property1 4 ;
+  ex:property2 6 ;
+.
+ex:ValidResource2
+  ex:property1 3.1 ;
+  ex:property1 3.2 ;
+.
+ex:property1
+  rdf:type rdf:Property ;
+.
+ex:property2
+  rdf:type rdf:Property ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <lessThan-001>
+    ) ;
+.
+<lessThan-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:lessThan at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value 4 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value 6 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource3 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value 5 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/lessThan-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/lessThan-002.ttl
@@ -1,0 +1,81 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThan-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  ex:first 1 ;
+  ex:first 2 ;
+  ex:second "a" ;
+  ex:second "b" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-first ;
+  sh:targetNode ex:InvalidInstance1 ;
+.
+ex:TestShape-first
+  sh:path ex:first ;
+  sh:lessThan ex:second ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <lessThan-002>
+    ) ;
+.
+<lessThan-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:lessThan at property shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:first ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-first ;
+          sh:value 1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:first ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-first ;
+          sh:value 1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:first ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-first ;
+          sh:value 2 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:first ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanConstraintComponent ;
+          sh:sourceShape ex:TestShape-first ;
+          sh:value 2 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/lessThanOrEquals-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/lessThanOrEquals-001.ttl
@@ -1,0 +1,87 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/lessThanOrEquals-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 5 ;
+  ex:property2 4 ;
+.
+ex:InvalidResource2
+  ex:property1 4 ;
+  ex:property1 6 ;
+  ex:property2 5 ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+  sh:targetNode ex:ValidResource3 ;
+.
+ex:TestShape-property1
+  sh:path ex:property1 ;
+  sh:lessThanOrEquals ex:property2 ;
+.
+ex:ValidResource1
+  ex:property1 4 ;
+  ex:property2 6 ;
+.
+ex:ValidResource2
+  ex:property1 3.1 ;
+  ex:property1 3.2 ;
+.
+ex:ValidResource3
+  ex:property1 5 ;
+  ex:property2 5 ;
+.
+ex:property1
+  rdf:type rdf:Property ;
+.
+ex:property2
+  rdf:type rdf:Property ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <lessThanOrEquals-001>
+    ) ;
+.
+<lessThanOrEquals-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:lessThanOrEquals at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanOrEqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value 5 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:property1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:LessThanOrEqualsConstraintComponent ;
+          sh:sourceShape ex:TestShape-property1 ;
+          sh:value 6 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/manifest.ttl
@@ -1,0 +1,46 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/property" ;
+	mf:include <and-001.ttl> ;
+	mf:include <class-001.ttl> ;
+	mf:include <datatype-001.ttl> ;
+	mf:include <datatype-002.ttl> ;
+	mf:include <datatype-003.ttl> ;
+	mf:include <datatype-ill-formed.ttl> ;
+	mf:include <disjoint-001.ttl> ;
+	mf:include <equals-001.ttl> ;
+	mf:include <hasValue-001.ttl> ;
+	mf:include <in-001.ttl> ;
+	mf:include <languageIn-001.ttl> ;
+	mf:include <lessThan-001.ttl> ;
+	mf:include <lessThan-002.ttl> ;
+	mf:include <lessThanOrEquals-001.ttl> ;
+	mf:include <maxCount-001.ttl> ;
+	mf:include <maxCount-002.ttl> ;
+	mf:include <maxExclusive-001.ttl> ;
+	mf:include <maxInclusive-001.ttl> ;
+	mf:include <maxLength-001.ttl> ;
+	mf:include <minCount-001.ttl> ;
+	mf:include <minCount-002.ttl> ;
+	mf:include <minExclusive-001.ttl> ;
+	mf:include <minExclusive-002.ttl> ;
+	mf:include <minLength-001.ttl> ;
+	mf:include <node-001.ttl> ;
+	mf:include <node-002.ttl> ;
+	mf:include <nodeKind-001.ttl> ;
+	mf:include <not-001.ttl> ;
+	mf:include <or-001.ttl> ;
+	mf:include <or-datatypes-001.ttl> ;
+	mf:include <pattern-001.ttl> ;
+	mf:include <pattern-002.ttl> ;
+	mf:include <property-001.ttl> ;
+	mf:include <qualifiedMinCountDisjoint-001.ttl> ;
+	mf:include <qualifiedValueShape-001.ttl> ;
+	mf:include <qualifiedValueShapesDisjoint-001.ttl> ;
+	mf:include <uniqueLang-001.ttl> ;
+	mf:include <uniqueLang-002.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxCount-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxCount-001.ttl
@@ -1,0 +1,64 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidPerson
+  rdf:type ex:Person ;
+  ex:firstName "George" ;
+  ex:firstName "John" ;
+  rdfs:label "Invalid person" ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdfs:label "Person" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:PersonShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:PersonShape-firstName ;
+  sh:targetClass ex:Person ;
+  sh:targetNode ex:ValidResource ;
+.
+ex:PersonShape-firstName
+  sh:path ex:firstName ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+.
+ex:ValidResource
+  rdf:type ex:Person ;
+  ex:firstName "John" ;
+  rdfs:label "Valid resource" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxCount-001>
+    ) ;
+.
+<maxCount-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxCount at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidPerson ;
+          sh:resultPath ex:firstName ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:PersonShape-firstName ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxCount-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxCount-002.ttl
@@ -1,0 +1,57 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/maxCount-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource
+  rdf:type rdfs:Resource ;
+  rdfs:label "Invalid resource" ;
+  owl:versionInfo "1.0" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-versionInfo ;
+  sh:targetNode ex:InvalidResource ;
+  sh:targetNode ex:ValidResource ;
+.
+ex:TestShape-versionInfo
+  sh:path owl:versionInfo ;
+  sh:maxCount 0 ;
+.
+ex:ValidResource
+  rdf:type rdfs:Resource ;
+  rdfs:label "Valid resource" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxCount-002>
+    ) ;
+.
+<maxCount-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxCount at property shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultPath owl:versionInfo ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-versionInfo ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxExclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxExclusive-001.ttl
@@ -1,0 +1,84 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/maxExclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property 1 ;
+.
+ex:InvalidResource2
+  ex:property 2 ;
+.
+ex:InvalidResource3
+  ex:property "a" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-property ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:InvalidResource3 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-property
+  sh:path ex:property ;
+  sh:maxExclusive 1 ;
+.
+ex:ValidResource1
+  ex:property 0 ;
+.
+ex:ValidResource2
+  ex:property -1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxExclusive-001>
+    ) ;
+.
+<maxExclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxExclusive at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value 1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value 2 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource3 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value "a" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxInclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxInclusive-001.ttl
@@ -1,0 +1,71 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/maxInclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property 2 ;
+.
+ex:InvalidResource2
+  ex:property "a" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-property ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-property
+  sh:path ex:property ;
+  sh:maxInclusive 1 ;
+.
+ex:ValidResource1
+  ex:property 0 ;
+.
+ex:ValidResource2
+  ex:property 1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxInclusive-001>
+    ) ;
+.
+<maxInclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxInclusive at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value 2 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxInclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value "a" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxLength-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/maxLength-001.ttl
@@ -1,0 +1,61 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/maxLength-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "ABC" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-testProperty ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  sh:datatype xsd:string ;
+  sh:maxLength 2 ;
+.
+ex:ValidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "A" ;
+  ex:testProperty "AB" ;
+.
+ex:ValidInstance2
+  rdf:type ex:TestShape ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <maxLength-001>
+    ) ;
+.
+<maxLength-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:maxLength at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value "ABC" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minCount-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minCount-001.ttl
@@ -1,0 +1,62 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidPerson
+  rdf:type ex:Person ;
+  rdfs:label "Invalid person" ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdfs:label "Person" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:PersonShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:PersonShape-firstName ;
+  sh:targetClass ex:Person ;
+  sh:targetNode ex:ValidResource ;
+.
+ex:PersonShape-firstName
+  sh:path ex:firstName ;
+  sh:datatype xsd:string ;
+  sh:minCount 1 ;
+.
+ex:ValidResource
+  rdf:type ex:Person ;
+  ex:firstName "John" ;
+  rdfs:label "Valid resource" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minCount-001>
+    ) ;
+.
+<minCount-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minCount at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidPerson ;
+          sh:resultPath ex:firstName ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+          sh:sourceShape ex:PersonShape-firstName ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minCount-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minCount-002.ttl
@@ -1,0 +1,41 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/minCount-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property [
+      sh:path ex:property ;
+      sh:minCount 0 ;
+      sh:name "property" ;
+    ] ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minCount-002>
+    ) ;
+.
+<minCount-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minCount at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minExclusive-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minExclusive-001.ttl
@@ -1,0 +1,69 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty 40 ;
+.
+ex:InvalidInstance2
+  rdf:type ex:TestShape ;
+  ex:testProperty 39 ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-testProperty ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  sh:minExclusive 40 ;
+.
+ex:ValidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty 42 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minExclusive-001>
+    ) ;
+.
+<minExclusive-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minExclusive at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value 40 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value 39 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minExclusive-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minExclusive-002.ttl
@@ -1,0 +1,65 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/minExclusive-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "A string" ;
+.
+ex:InvalidInstance2
+  rdf:type ex:TestShape ;
+  ex:testProperty rdfs:Resource ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-testProperty ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  sh:minExclusive 40 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minExclusive-002>
+    ) ;
+.
+<minExclusive-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minExclusive at property shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value "A string" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value rdfs:Resource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minLength-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/minLength-001.ttl
@@ -1,0 +1,61 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/minLength-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "A" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-testProperty ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  sh:datatype xsd:string ;
+  sh:minLength 2 ;
+.
+ex:ValidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "AB" ;
+  ex:testProperty "ABC" ;
+.
+ex:ValidInstance2
+  rdf:type ex:TestShape ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <minLength-001>
+    ) ;
+.
+<minLength-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:minLength at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MinLengthConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+          sh:value "A" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/node-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/node-001.ttl
@@ -1,0 +1,113 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/node-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Anon
+  rdf:type ex:Person ;
+  ex:firstName "Anon" ;
+.
+ex:Issue
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Issue" ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property ex:Issue-assignedTo ;
+  sh:property ex:Issue-submittedBy ;
+.
+ex:Issue-assignedTo
+  sh:path ex:assignedTo ;
+  sh:class ex:Person ;
+  sh:node [
+      rdfs:comment "All assignees must have an email and a last name." ;
+      sh:property [
+          sh:path ex:email ;
+          sh:maxCount 1 ;
+          sh:minCount 1 ;
+        ] ;
+      sh:property [
+          sh:path ex:lastName ;
+          sh:maxCount 1 ;
+          sh:minCount 1 ;
+        ] ;
+    ] ;
+.
+ex:Issue-submittedBy
+  sh:path ex:submittedBy ;
+  sh:class ex:Person ;
+  sh:minCount 1 ;
+.
+ex:Issue_1
+  rdf:type ex:Issue ;
+  ex:assignedTo ex:Anon ;
+  ex:submittedBy ex:Anon ;
+  rdfs:label "Issue 1" ;
+.
+ex:Issue_2
+  rdf:type ex:Issue ;
+  ex:assignedTo ex:JohnDoeWithEmail ;
+  ex:submittedBy ex:Anon ;
+  rdfs:label "Issue 2" ;
+.
+ex:JohnDoeWithEmail
+  rdf:type ex:Person ;
+  ex:email "john@doe.com" ;
+  ex:firstName "John" ;
+  ex:lastName "Doe" ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Person" ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+      sh:path ex:email ;
+      ex:datatype xsd:string ;
+      rdfs:label "email" ;
+    ] ;
+  sh:property [
+      sh:path ex:firstName ;
+      rdfs:label "first name" ;
+      sh:datatype xsd:string ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+    ] ;
+  sh:property [
+      sh:path ex:lastName ;
+      rdfs:label "last name" ;
+      sh:datatype xsd:string ;
+    ] ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <node-001>
+    ) ;
+.
+<node-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:node at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Issue_1 ;
+          sh:resultPath ex:assignedTo ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+          sh:sourceShape ex:Issue-assignedTo ;
+          sh:value ex:Anon ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/node-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/node-002.ttl
@@ -1,0 +1,75 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/node-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:AddressShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:AddressShape-postalCode ;
+.
+ex:AddressShape-postalCode
+  sh:path ex:postalCode ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+.
+ex:Bob
+  rdf:type ex:Person ;
+  ex:address ex:BobsAddress ;
+.
+ex:BobsAddress
+  ex:postalCode "1234" ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdfs:label "Person" ;
+.
+ex:PersonShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:PersonShape-address ;
+  sh:targetClass ex:Person ;
+.
+ex:PersonShape-address
+  sh:path ex:address ;
+  sh:minCount 1 ;
+  sh:node ex:AddressShape ;
+.
+ex:Reto
+  rdf:type ex:Person ;
+  ex:address ex:RetosAddress ;
+.
+ex:RetosAddress
+  ex:postalCode 5678 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <node-002>
+    ) ;
+.
+<node-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:node at property shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Reto ;
+          sh:resultPath ex:address ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+          sh:sourceShape ex:PersonShape-address ;
+          sh:value ex:RetosAddress ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/nodeKind-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/nodeKind-001.ttl
@@ -1,0 +1,371 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/nodeKind-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InstanceWithBlankNode
+  rdf:type ex:MyClass ;
+  ex:myProperty _:b55454 ;
+.
+ex:InstanceWithBlankNodeAndIRI
+  rdf:type ex:MyClass ;
+  ex:myProperty rdfs:Class ;
+  ex:myProperty _:b67098 ;
+.
+ex:InstanceWithBlankNodeAndLiteral
+  rdf:type ex:MyClass ;
+  ex:myProperty "Literal" ;
+  ex:myProperty _:b99026 ;
+.
+ex:InstanceWithIRI
+  rdf:type ex:MyClass ;
+  ex:myProperty rdfs:Class ;
+.
+ex:InstanceWithIRIAndLiteral
+  rdf:type ex:MyClass ;
+  ex:myProperty rdfs:Class ;
+  ex:myProperty "Literal" ;
+.
+ex:InstanceWithLiteral
+  rdf:type ex:MyClass ;
+  ex:myProperty "Literal" ;
+.
+ex:MyClass
+  rdf:type rdfs:Class ;
+  rdfs:label "My class" ;
+.
+ex:ShapeWithBlankNode
+  rdf:type sh:NodeShape ;
+  sh:property _:b38619 ;
+  sh:targetClass ex:MyClass ;
+.
+ex:ShapeWithBlankNodeOrIRI
+  rdf:type sh:NodeShape ;
+  sh:property _:b3078 ;
+  sh:targetClass ex:MyClass ;
+.
+ex:ShapeWithBlankNodeOrLiteral
+  rdf:type sh:NodeShape ;
+  sh:property _:b14975 ;
+  sh:targetClass ex:MyClass ;
+.
+ex:ShapeWithIRI
+  rdf:type sh:NodeShape ;
+  sh:property _:b97614 ;
+  sh:targetClass ex:MyClass ;
+.
+ex:ShapeWithIRIOrLiteral
+  rdf:type sh:NodeShape ;
+  sh:property _:b97860 ;
+  sh:targetClass ex:MyClass ;
+.
+ex:ShapeWithLiteral
+  rdf:type sh:NodeShape ;
+  sh:property _:b79526 ;
+  sh:targetClass ex:MyClass ;
+.
+ex:myProperty
+  rdf:type rdf:Property ;
+  rdfs:domain ex:MyClass ;
+  rdfs:label "my property" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <nodeKind-001>
+    ) ;
+.
+<nodeKind-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:nodeKind at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNode ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b79526 ;
+          sh:value _:b55454 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNode ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97614 ;
+          sh:value _:b55454 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNode ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97860 ;
+          sh:value _:b55454 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b14975 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b38619 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b79526 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b79526 ;
+          sh:value _:b67098 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97614 ;
+          sh:value _:b67098 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97860 ;
+          sh:value _:b67098 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b3078 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b38619 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b79526 ;
+          sh:value _:b99026 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97614 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97614 ;
+          sh:value _:b99026 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithBlankNodeAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97860 ;
+          sh:value _:b99026 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b14975 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b38619 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRI ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b79526 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRIAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b3078 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRIAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b14975 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRIAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b38619 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRIAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b38619 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRIAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b79526 ;
+          sh:value rdfs:Class ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithIRIAndLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97614 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b3078 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b38619 ;
+          sh:value "Literal" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InstanceWithLiteral ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+          sh:sourceShape _:b97614 ;
+          sh:value "Literal" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b3078
+  sh:path ex:myProperty ;
+  sh:nodeKind sh:BlankNodeOrIRI ;
+.
+_:b14975
+  sh:path ex:myProperty ;
+  sh:nodeKind sh:BlankNodeOrLiteral ;
+.
+_:b38619
+  sh:path ex:myProperty ;
+  sh:nodeKind sh:BlankNode ;
+.
+_:b55454
+  rdf:type rdfs:Resource ;
+.
+_:b67098
+  rdf:type rdfs:Resource ;
+.
+_:b79526
+  sh:path ex:myProperty ;
+  sh:nodeKind sh:Literal ;
+.
+_:b97614
+  sh:path ex:myProperty ;
+  sh:nodeKind sh:IRI ;
+.
+_:b97860
+  sh:path ex:myProperty ;
+  sh:nodeKind sh:IRIOrLiteral ;
+.
+_:b99026
+  rdf:type rdfs:Resource ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/not-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/not-001.ttl
@@ -1,0 +1,68 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/not-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  ex:property 42 ;
+  ex:property "Test Valid" ;
+  rdfs:label "Invalid resource1" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-property ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:TestShape-property
+  sh:path ex:property ;
+  sh:not [
+      sh:datatype xsd:integer ;
+    ] ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+  rdfs:label "Valid resource1" ;
+.
+ex:ValidResource2
+  rdf:type rdfs:Resource ;
+  ex:property 1.5 ;
+  ex:property "String" ;
+  rdfs:label "Valid resource2" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <not-001>
+    ) ;
+.
+<not-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:not at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:NotConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value 42 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/or-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/or-001.ttl
@@ -1,0 +1,76 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/or-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Address
+  rdf:type rdfs:Class ;
+  rdfs:label "Address" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:AddressShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Address shape" ;
+  sh:property ex:AddressShape-address ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+  sh:targetNode ex:ValidResource2 ;
+.
+ex:AddressShape-address
+  sh:path ex:address ;
+  sh:or (
+      [
+        sh:datatype xsd:string ;
+      ]
+      [
+        sh:class ex:Address ;
+      ]
+    ) ;
+.
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  ex:address "true"^^xsd:boolean ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+  ex:address "Home" ;
+.
+ex:ValidResource2
+  rdf:type rdfs:Resource ;
+  ex:address [
+      rdf:type ex:Address ;
+    ] ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <or-001>
+    ) ;
+.
+<or-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:or at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath ex:address ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:AddressShape-address ;
+          sh:value "true"^^xsd:boolean ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/or-datatypes-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/or-datatypes-001.ttl
@@ -1,0 +1,95 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/or-datatypes-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  rdfs:comment owl:Thing ;
+  rdfs:comment 42 ;
+  rdfs:comment "A string" ;
+  rdfs:comment "none"^^xsd:boolean ;
+  rdfs:label "Invalid resource1" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-comment ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:TestShape-comment
+  sh:path rdfs:comment ;
+  sh:or (
+      [
+        sh:datatype xsd:string ;
+      ]
+      [
+        sh:datatype rdf:HTML ;
+      ]
+      [
+        sh:datatype rdf:langString ;
+      ]
+      [
+        sh:datatype xsd:boolean ;
+      ]
+    ) ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+  rdfs:comment "<div>HTML</div>"^^rdf:HTML ;
+  rdfs:comment "A language string"@en ;
+  rdfs:comment "A string" ;
+  rdfs:label "Valid resource1" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <or-datatypes-001>
+    ) ;
+.
+<or-datatypes-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:or of sh:datatypes at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath rdfs:comment ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:TestShape-comment ;
+          sh:value owl:Thing ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath rdfs:comment ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:TestShape-comment ;
+          sh:value 42 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath rdfs:comment ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:OrConstraintComponent ;
+          sh:sourceShape ex:TestShape-comment ;
+          sh:value "none"^^xsd:boolean ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/pattern-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/pattern-001.ttl
@@ -1,0 +1,74 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:property "Maria" ;
+  rdfs:label "Invalid instance1" ;
+.
+ex:InvalidInstance2
+  rdf:type ex:TestShape ;
+  ex:property "john" ;
+  rdfs:label "Invalid instance2" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-property ;
+.
+ex:TestShape-property
+  sh:path ex:property ;
+  sh:datatype xsd:string ;
+  sh:pattern "Joh" ;
+.
+ex:ValidInstance1
+  rdf:type ex:TestShape ;
+  ex:property "Hi Joh" ;
+  ex:property "John" ;
+  rdfs:label "Valid instance1" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pattern-001>
+    ) ;
+.
+<pattern-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:pattern at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value "Maria" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value "john" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/pattern-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/pattern-002.ttl
@@ -1,0 +1,66 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/pattern-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:property "Maria" ;
+  rdfs:label "Invalid instance1" ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-property ;
+.
+ex:TestShape-property
+  sh:path ex:property ;
+  rdfs:label "property" ;
+  sh:datatype xsd:string ;
+  sh:flags "i" ;
+  sh:pattern "joh" ;
+.
+ex:ValidInstance1
+  rdf:type ex:TestShape ;
+  ex:property "Hi Joh" ;
+  ex:property "John" ;
+  rdfs:label "Valid instance1" ;
+.
+ex:ValidInstance2
+  rdf:type ex:TestShape ;
+  ex:property "john" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pattern-002>
+    ) ;
+.
+<pattern-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:pattern at property shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:property ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:PatternConstraintComponent ;
+          sh:sourceShape ex:TestShape-property ;
+          sh:value "Maria" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/property-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/property-001.ttl
@@ -1,0 +1,100 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/property-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Address
+  rdf:type rdfs:Class ;
+  rdfs:label "Address" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:City
+  rdf:type rdfs:Class ;
+  rdfs:label "City" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:InvalidAddress
+  rdf:type ex:Address ;
+  ex:city ex:InvalidCity ;
+.
+ex:InvalidPerson1
+  rdf:type ex:Person ;
+  ex:address ex:InvalidAddress ;
+.
+ex:InvalidPerson2
+  rdf:type ex:Person ;
+  ex:address ex:InvalidAddress ;
+  ex:address ex:ValidAddress ;
+.
+ex:Person
+  rdf:type rdfs:Class ;
+  rdfs:label "Person" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:PersonShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Person shape" ;
+  sh:property [
+      sh:path ex:address ;
+      sh:property ex:PersonShape-address-city ;
+    ] ;
+  sh:targetClass ex:Person ;
+.
+ex:PersonShape-address-city
+  sh:path ex:city ;
+  sh:class ex:City ;
+.
+ex:ProperCity
+  rdf:type ex:City ;
+  rdfs:label "Proper city" ;
+.
+ex:ValidAddress
+  rdf:type ex:Address ;
+  ex:city ex:ProperCity ;
+.
+ex:ValidPerson1
+  rdf:type ex:Person ;
+  ex:address ex:ValidAddress ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <property-001>
+    ) ;
+.
+<property-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:property at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidAddress ;
+          sh:resultPath ex:city ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:PersonShape-address-city ;
+          sh:value ex:InvalidCity ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidAddress ;
+          sh:resultPath ex:city ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+          sh:sourceShape ex:PersonShape-address-city ;
+          sh:value ex:InvalidCity ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/qualifiedMinCountDisjoint-001.ttl
@@ -1,0 +1,116 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedMinCountDisjoint-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Digit
+  rdf:type rdfs:Class ;
+  rdfs:label "Digit" ;
+.
+ex:Finger
+  rdf:type rdfs:Class ;
+  rdfs:label "Finger" ;
+  rdfs:subClassOf ex:Digit ;
+.
+ex:FingerAndThumb
+  rdf:type ex:Finger ;
+  rdf:type ex:Thumb ;
+  rdfs:label "Finger and thumb" ;
+.
+ex:FingerShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Finger shape" ;
+  sh:class ex:Finger ;
+.
+ex:Finger_1
+  rdf:type ex:Finger ;
+  rdfs:label "Finger 1" ;
+.
+ex:Hand
+  rdf:type rdfs:Class ;
+  rdfs:label "Hand" ;
+.
+ex:HandShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Hand shape" ;
+  sh:property ex:HandShape-digit-maxCount4 ;
+  sh:property ex:HandShape-digit-minCount1 ;
+  sh:targetClass ex:Hand ;
+.
+ex:HandShape-digit-maxCount4
+  rdf:type sh:PropertyShape ;
+  sh:path ex:digit ;
+  sh:qualifiedMaxCount 4 ;
+  sh:qualifiedValueShape ex:FingerShape ;
+  sh:qualifiedValueShapesDisjoint "true"^^xsd:boolean ;
+.
+ex:HandShape-digit-minCount1
+  rdf:type sh:PropertyShape ;
+  sh:path ex:digit ;
+  sh:qualifiedMinCount 1 ;
+  sh:qualifiedValueShape ex:ThumbShape ;
+  sh:qualifiedValueShapesDisjoint "true"^^xsd:boolean ;
+.
+ex:InvalidHand1
+  rdf:type ex:Hand ;
+  ex:digit ex:FingerAndThumb ;
+  rdfs:label "Invalid hand1" ;
+.
+ex:Thumb
+  rdf:type rdfs:Class ;
+  rdfs:label "Thumb" ;
+  rdfs:subClassOf ex:Digit ;
+.
+ex:ThumbShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Thumb shape" ;
+  sh:class ex:Thumb ;
+.
+ex:Thumb_1
+  rdf:type ex:Thumb ;
+  rdfs:label "Thumb 1" ;
+.
+ex:ValidHand1
+  rdf:type ex:Hand ;
+  ex:digit ex:Finger_1 ;
+  ex:digit ex:Thumb_1 ;
+  rdfs:label "Valid hand1" ;
+.
+ex:digit
+  rdf:type rdf:Property ;
+  rdfs:domain ex:Hand ;
+  rdfs:label "digit" ;
+  rdfs:range ex:Digit ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <qualifiedMinCountDisjoint-001>
+    ) ;
+.
+<qualifiedMinCountDisjoint-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:qualifiedMinCount with disjoint shapes at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidHand1 ;
+          sh:resultPath ex:digit ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent ;
+          sh:sourceShape ex:HandShape-digit-minCount1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/qualifiedValueShape-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/qualifiedValueShape-001.ttl
@@ -1,0 +1,80 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShape-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:APGARObservationShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:APGARObservationShape-related ;
+  sh:targetNode ex:Observation1 ;
+.
+ex:APGARObservationShape-related
+  sh:path ex:related ;
+  sh:qualifiedMaxCount 3 ;
+  sh:qualifiedMinCount 3 ;
+  sh:qualifiedValueShape [
+      sh:property [
+          sh:path ex:related_target ;
+          sh:node [
+              sh:property [
+                  sh:path ex:reference ;
+                  sh:hasValue ex:something ;
+                ] ;
+            ] ;
+        ] ;
+    ] ;
+.
+ex:Observation1
+  rdf:type ex:Observation ;
+  ex:related [
+      ex:related_target [
+          ex:reference ex:something ;
+        ] ;
+      ex:related_type "has-component"^^ex:code ;
+    ] ;
+  ex:related [
+      ex:related_target [
+          ex:reference ex:something ;
+        ] ;
+      ex:related_type "has-component"^^ex:code ;
+    ] ;
+  ex:related [
+      ex:related_target [
+          ex:reference ex:unrelated ;
+        ] ;
+      ex:related_type "has-component"^^ex:code ;
+    ] ;
+  sh:nodeShape ex:APGARObservationShape ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <qualifiedValueShape-001>
+    ) ;
+.
+<qualifiedValueShape-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:qualifiedValueShape at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:Observation1 ;
+          sh:resultPath ex:related ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent ;
+          sh:sourceShape ex:APGARObservationShape-related ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/qualifiedValueShapesDisjoint-001.ttl
@@ -1,0 +1,128 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/qualifiedValueShapesDisjoint-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Finger
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Finger" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:Finger1
+  rdf:type ex:Finger ;
+  rdfs:label "Finger1" ;
+.
+ex:Finger2
+  rdf:type ex:Finger ;
+  rdfs:label "Finger2" ;
+.
+ex:Finger3
+  rdf:type ex:Finger ;
+  rdfs:label "Finger3" ;
+.
+ex:Finger4
+  rdf:type ex:Finger ;
+  rdfs:label "Finger4" ;
+.
+ex:FingerAndThumb
+  rdf:type ex:Finger ;
+  rdf:type ex:Thumb ;
+  rdfs:label "Finger and thumb" ;
+.
+ex:Hand
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Hand" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:HandShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:HandShape-digit1 ;
+  sh:property ex:HandShape-digit4 ;
+  sh:targetClass ex:Hand ;
+.
+ex:HandShape-digit1
+  sh:path ex:digit ;
+  sh:qualifiedMaxCount 1 ;
+  sh:qualifiedMinCount 1 ;
+  sh:qualifiedValueShape [
+      sh:class ex:Thumb ;
+    ] ;
+  sh:qualifiedValueShapesDisjoint "true"^^xsd:boolean ;
+.
+ex:HandShape-digit4
+  sh:path ex:digit ;
+  sh:qualifiedMaxCount 4 ;
+  sh:qualifiedMinCount 4 ;
+  sh:qualifiedValueShape [
+      sh:class ex:Finger ;
+    ] ;
+  sh:qualifiedValueShapesDisjoint "true"^^xsd:boolean ;
+.
+ex:InvalidHand1
+  rdf:type ex:Hand ;
+  ex:digit ex:Finger1 ;
+  ex:digit ex:Finger2 ;
+  ex:digit ex:Finger3 ;
+  ex:digit ex:FingerAndThumb ;
+.
+ex:Thumb
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Thumb" ;
+  rdfs:subClassOf rdfs:Resource ;
+.
+ex:Thumb1
+  rdf:type ex:Thumb ;
+  rdfs:label "Thumb1" ;
+.
+ex:ValidHand
+  rdf:type ex:Hand ;
+  ex:digit ex:Finger1 ;
+  ex:digit ex:Finger2 ;
+  ex:digit ex:Finger3 ;
+  ex:digit ex:Finger4 ;
+  ex:digit ex:Thumb1 ;
+  rdfs:label "Valid hand" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <qualifiedValueShapesDisjoint-001>
+    ) ;
+.
+<qualifiedValueShapesDisjoint-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:qualifiedValueShapesDisjoint at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidHand1 ;
+          sh:resultPath ex:digit ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent ;
+          sh:sourceShape ex:HandShape-digit1 ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidHand1 ;
+          sh:resultPath ex:digit ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent ;
+          sh:sourceShape ex:HandShape-digit4 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-001.ttl
@@ -1,0 +1,86 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/property/uniqueLang-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "Me" ;
+  ex:testProperty "Me"@en ;
+  ex:testProperty "Moi"@fr ;
+  ex:testProperty "Myself"@en ;
+.
+ex:InvalidInstance2
+  rdf:type ex:TestShape ;
+  ex:testProperty "I"@en ;
+  ex:testProperty "Ich"@de ;
+  ex:testProperty "Me"@en ;
+  ex:testProperty "Mich"@de ;
+  ex:testProperty "Myself"@en ;
+.
+ex:TestShape
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-testProperty ;
+.
+ex:TestShape-testProperty
+  sh:path ex:testProperty ;
+  rdfs:label "test property" ;
+  sh:uniqueLang "true"^^xsd:boolean ;
+.
+ex:ValidInstance1
+  rdf:type ex:TestShape ;
+  ex:testProperty "Me" ;
+  ex:testProperty "Me"@en ;
+  ex:testProperty "Moi"@fr ;
+  ex:testProperty "Myself" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <uniqueLang-001>
+    ) ;
+.
+<uniqueLang-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:uniqueLang at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:UniqueLangConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:UniqueLangConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:testProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:UniqueLangConstraintComponent ;
+          sh:sourceShape ex:TestShape-testProperty ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-002-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-002-data.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:i ex:message "HI"@en, "Hi"@en .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-002-shapes.ttl
@@ -1,0 +1,12 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl-test/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:s1 a sh:PropertyShape ;
+  sh:targetNode ex:i ;
+  sh:path ex:message ;
+  sh:uniqueLang "1"^^xsd:boolean .
+
+# Note that the value above is "1"^^xsd:boolean, which is distinct from "true"^^xsd:boolean.
+# Only true is mentioned in the spec, meaning that "1" will not activate the constraint
+# and the constraint is being ignored.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/property/uniqueLang-002.ttl
@@ -1,0 +1,23 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/path/path-complex-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a mf:Manifest ;
+  mf:entries (
+      <uniqueLang-002>
+    ) .
+
+<uniqueLang-002> a sht:Validate ;
+  rdfs:label "Test uniqueLang with other boolean literal for true" ;
+  mf:action [
+      sht:dataGraph <uniqueLang-002-data.ttl> ;
+      sht:shapesGraph <uniqueLang-002-shapes.ttl> ] ;
+  mf:result [ a sh:ValidationReport ;
+      sh:conforms "true"^^xsd:boolean ] ;
+  mf:status sht:approved .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/manifest.ttl
@@ -1,0 +1,15 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/core/targets" ;
+	mf:include <multipleTargets-001.ttl> ;
+	mf:include <targetClass-001.ttl> ;
+	mf:include <targetClassImplicit-001.ttl> ;
+	mf:include <targetNode-001.ttl> ;
+	mf:include <targetObjectsOf-001.ttl> ;
+	mf:include <targetSubjectsOf-001.ttl> ;
+	mf:include <targetSubjectsOf-002.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/multipleTargets-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/multipleTargets-001.ttl
@@ -1,0 +1,56 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/multipleTargets-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:property1 "Also a value" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:in (
+      ex:ValidResource1
+      ex:ValidResource2
+    ) ;
+  sh:targetSubjectsOf ex:property1 ;
+  sh:targetSubjectsOf ex:property2 ;
+.
+ex:ValidResource1
+  ex:property1 "Some value" ;
+.
+ex:ValidResource2
+  ex:property2 "Other value" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <multipleTargets-001>
+    ) ;
+.
+<multipleTargets-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of multiple targets 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:InConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource1 ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetClass-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetClass-001.ttl
@@ -1,0 +1,62 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClass-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:MyClass ;
+  ex:myProperty "A" ;
+  ex:myProperty "B" ;
+.
+ex:MyClass
+  rdf:type rdfs:Class ;
+.
+ex:MyShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:MyShape-myProperty ;
+  sh:targetClass ex:MyClass ;
+.
+ex:MyShape-myProperty
+  sh:path ex:myProperty ;
+  sh:maxCount 1 ;
+.
+ex:ValidInstance1
+  rdf:type ex:MyClass ;
+  ex:myProperty "A" ;
+.
+ex:ValidInstance2
+  ex:myProperty "A" ;
+  ex:myProperty "B" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <targetClass-001>
+    ) ;
+.
+<targetClass-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:targetClass 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:MyShape-myProperty ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetClassImplicit-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetClassImplicit-001.ttl
@@ -1,0 +1,58 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetClassImplicit-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance
+  rdf:type ex:SubClass ;
+  rdfs:label "Invalid instance" ;
+.
+ex:SubClass
+  rdf:type rdfs:Class ;
+  rdfs:label "Sub class" ;
+  rdfs:subClassOf ex:SuperClass ;
+.
+ex:SuperClass
+  rdf:type rdfs:Class ;
+  rdf:type sh:NodeShape ;
+  rdfs:label "Super class" ;
+  sh:in (
+      ex:ValidInstance
+    ) ;
+.
+ex:ValidInstance
+  rdf:type ex:SubClass ;
+  rdfs:label "Valid instance" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <targetClassImplicit-001>
+    ) ;
+.
+<targetClassImplicit-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of implicit sh:targetClass 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:InConstraintComponent ;
+          sh:sourceShape ex:SuperClass ;
+          sh:value ex:InvalidInstance ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetNode-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetNode-001.ttl
@@ -1,0 +1,57 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetNode-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  rdfs:label "Invalid resource 1" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:property ex:TestShape-label ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:TestShape-label
+  sh:path rdfs:label ;
+  rdfs:label "label" ;
+  sh:datatype xsd:string ;
+  sh:maxCount 0 ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <targetNode-001>
+    ) ;
+.
+<targetNode-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:targetNode 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath rdfs:label ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-label ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetObjectsOf-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetObjectsOf-001.ttl
@@ -1,0 +1,65 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetObjectsOf-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  ex:testProperty "String" ;
+.
+ex:InvalidResource2
+  ex:testProperty rdfs:Resource ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:datatype xsd:integer ;
+  sh:targetObjectsOf ex:testProperty ;
+.
+ex:ValidResource1
+  ex:testProperty 100 ;
+  ex:testProperty 42 ;
+.
+ex:testProperty
+  rdf:type rdf:Property ;
+  rdfs:label "test property" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <targetObjectsOf-001>
+    ) ;
+.
+<targetObjectsOf-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:targetObjectsOf 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode rdfs:Resource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value rdfs:Resource ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "String" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "String" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-001.ttl
@@ -1,0 +1,57 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  ex:myProperty "A" ;
+  ex:myProperty "B" ;
+.
+ex:MyClass
+  rdf:type rdfs:Class ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-myProperty ;
+  sh:targetSubjectsOf ex:myProperty ;
+.
+ex:TestShape-myProperty
+  rdf:type sh:PropertyShape ;
+  sh:path ex:myProperty ;
+  sh:maxCount 1 ;
+.
+ex:ValidInstance1
+  ex:myProperty "A" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <targetSubjectsOf-001>
+    ) ;
+.
+<targetSubjectsOf-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:targetSubjectsOf 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-myProperty ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/targets/targetSubjectsOf-002.ttl
@@ -1,0 +1,74 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/core/targets/targetSubjectsOf-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidInstance1
+  rdf:type ex:MyClass ;
+  ex:myProperty "A" ;
+  ex:myProperty "B" ;
+.
+ex:InvalidInstance2
+  ex:myProperty "A" ;
+  ex:myProperty "B" ;
+.
+ex:MyClass
+  rdf:type rdfs:Class ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:property ex:TestShape-myProperty ;
+  sh:targetClass ex:MyClass ;
+  sh:targetSubjectsOf ex:myProperty ;
+.
+ex:TestShape-myProperty
+  sh:path ex:myProperty ;
+  sh:maxCount 1 ;
+.
+ex:ValidInstance1
+  rdf:type ex:MyClass ;
+  ex:myProperty "A" ;
+.
+ex:ValidInstance2
+  ex:myProperty "A" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <targetSubjectsOf-002>
+    ) ;
+.
+<targetSubjectsOf-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:targetSubjectsOf 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance1 ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-myProperty ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidInstance2 ;
+          sh:resultPath ex:myProperty ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+          sh:sourceShape ex:TestShape-myProperty ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/manifest.ttl
@@ -1,0 +1,9 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests for validation reports" ;
+	mf:include <shared.ttl> ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/shared-data.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/shared-data.ttl
@@ -1,0 +1,4 @@
+@prefix ex: <http://example.org/shacl-test/> .
+ex:i ex:p ex:j .
+ex:i ex:q ex:j .
+ex:j ex:r ex:k .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/shared-shapes.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/shared-shapes.ttl
@@ -1,0 +1,16 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/shacl-test/> .
+
+ex:s1 a sh:NodeShape ;
+  sh:targetNode ex:i ;
+  sh:property ex:s2 ;
+  sh:property ex:s3 .
+
+ex:s2 sh:path ex:p ;
+  sh:property ex:s4 .
+
+ex:s3 sh:path ex:q ;
+  sh:property ex:s4 .
+
+ex:s4 sh:path ex:r ;
+  sh:class ex:C .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/shared.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/core/validation-reports/shared.ttl
@@ -1,0 +1,52 @@
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix ex: <http://example.org/shacl-test/> .
+
+# This test case is under discussion, as there are different interpretations
+# on whether the nested sh:property constraint that is reached twice should
+# also be reported twice.
+
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <shared>
+    ) ;
+.
+
+<shared>
+	rdf:type sht:Validate;
+	rdfs:label "Test of validation report for shape shared by property constraints" ;
+	mf:action [
+		sht:dataGraph <shared-data.ttl> ;
+		sht:shapesGraph <shared-shapes.ttl> 
+	] ;
+	mf:result [
+		rdf:type sh:ValidationReport ;
+		sh:conforms "false"^^xsd:boolean ;
+		sh:result [ 
+			rdf:type sh:ValidationResult ;
+			sh:resultSeverity sh:Violation ;
+			sh:focusNode ex:j ;
+			sh:value ex:k ;
+			sh:resultPath ex:r ;
+			sh:sourceShape ex:s4 ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent
+		] ;
+		sh:result [ 
+			rdf:type sh:ValidationResult ;
+			sh:resultSeverity sh:Violation ;
+			sh:focusNode ex:j ;
+			sh:value ex:k ;
+			sh:resultPath ex:r ;
+			sh:sourceShape ex:s4 ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent
+		]
+	] ;
+	mf:status sht:approved .
+  

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/manifest.ttl
@@ -1,0 +1,9 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	mf:include <core/manifest.ttl> ;
+	mf:include <sparql/manifest.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/manifest.ttl
@@ -1,0 +1,11 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/sparql/component" ;
+	mf:include <optional-001.ttl> ;
+	mf:include <propertyValidator-select-001.ttl> ;
+	mf:include <validator-001.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/nodeValidator-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/nodeValidator-001.ttl
@@ -1,0 +1,83 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test>
+  sh:declare [
+      rdf:type sh:PrefixDeclaration ;
+      sh:namespace "http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test#"^^xsd:anyURI ;
+      sh:prefix "ex" ;
+    ] ;
+.
+ex:InvalidResource1
+  ex:property "Other" ;
+.
+ex:TestConstraintComponent
+  rdf:type sh:ConstraintComponent ;
+  rdfs:label "Test constraint component" ;
+  sh:nodeValidator [
+      rdf:type sh:SPARQLSelectValidator ;
+      sh:select """
+      SELECT DISTINCT $this
+      WHERE {
+        $this ?p ?o .
+        FILTER NOT EXISTS {
+            $this ex:property ?requiredParam .
+      }}""" ;
+      sh:prefixes <http://datashapes.org/sh/tests/sparql/component/nodeValidator-001.test> ;
+    ] ;
+  sh:parameter [
+      sh:path ex:optionalParam ;
+      sh:datatype xsd:integer ;
+      sh:name "optional param" ;
+      sh:optional "true"^^xsd:boolean ;
+    ] ;
+  sh:parameter [
+      sh:path ex:requiredParam ;
+      sh:datatype xsd:string ;
+      sh:name "required param" ;
+    ] ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  ex:requiredParam "Value" ;
+  rdfs:label "Test shape" ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:ValidResource1
+  ex:property "Value" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <nodeValidator-001>
+    ) ;
+.
+<nodeValidator-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:nodeValidator 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:TestConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource1 ;
+        ] ;
+    ] ;
+  mf:status sht:proposed ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/optional-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/optional-001.ttl
@@ -1,0 +1,113 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/component/optional-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://datashapes.org/sh/tests/sparql/component/optional-001.test>
+  sh:declare [
+      rdf:type sh:PrefixDeclaration ;
+      sh:namespace "http://datashapes.org/sh/tests/sparql/component/optional-001.test#"^^xsd:anyURI ;
+      sh:prefix "ex" ;
+    ] ;
+.
+ex:IncompleteShape
+  rdf:type sh:NodeShape ;
+  ex:optionalParam "Some" ;
+  rdfs:label "Incomplete shape" ;
+  sh:targetNode "One" ;
+  sh:targetNode "Three" ;
+  sh:targetNode "Two" ;
+.
+ex:TestConstraintComponent
+  rdf:type sh:ConstraintComponent ;
+  rdfs:label "Test constraint component" ;
+  sh:parameter [
+      sh:path ex:optionalParam ;
+      sh:name "optional param" ;
+      sh:optional "true"^^xsd:boolean ;
+    ] ;
+  sh:parameter [
+      sh:path ex:requiredParam ;
+      sh:name "required param" ;
+    ] ;
+  sh:validator [
+      rdf:type sh:SPARQLAskValidator ;
+      sh:ask """ASK {
+    FILTER ($value != $requiredParam && $value != COALESCE(?optionalParam, \"Three\")) .
+}""" ;
+      sh:prefixes <http://datashapes.org/sh/tests/sparql/component/optional-001.test> ;
+    ] ;
+.
+ex:TestShape1
+  rdf:type sh:NodeShape ;
+  ex:requiredParam "One" ;
+  rdfs:label "Test shape 1" ;
+  sh:targetNode "One" ;
+  sh:targetNode "Three" ;
+  sh:targetNode "Two" ;
+.
+ex:TestShape2
+  rdf:type sh:NodeShape ;
+  ex:optionalParam "Two" ;
+  ex:requiredParam "One" ;
+  rdfs:label "Test shape 1" ;
+  sh:targetNode "One" ;
+  sh:targetNode "Three" ;
+  sh:targetNode "Two" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <optional-001>
+    ) ;
+.
+<optional-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:optional 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "One" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:TestConstraintComponent ;
+          sh:sourceShape ex:TestShape1 ;
+          sh:value "One" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "One" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:TestConstraintComponent ;
+          sh:sourceShape ex:TestShape2 ;
+          sh:value "One" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Three" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:TestConstraintComponent ;
+          sh:sourceShape ex:TestShape1 ;
+          sh:value "Three" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Two" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:TestConstraintComponent ;
+          sh:sourceShape ex:TestShape2 ;
+          sh:value "Two" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/propertyValidator-select-001.ttl
@@ -1,0 +1,107 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Country
+  rdf:type rdfs:Class ;
+  rdfs:label "Country" ;
+.
+ex:InvalidCountry1
+  rdf:type ex:Country ;
+  ex:englishLabel "Munich" ;
+  ex:germanLabel "Muenchen" ;
+  rdfs:label "Invalid country1" ;
+.
+ex:LanguageConstraintComponentUsingSELECT
+  rdf:type sh:ConstraintComponent ;
+  rdfs:label "Language constraint component" ;
+  sh:labelTemplate "Values are literals with language \"{$lang}\"" ;
+  sh:parameter [
+      sh:path ex:lang ;
+      sh:datatype xsd:string ;
+      sh:description "The language tag, e.g. \"de\"." ;
+      sh:minLength 2 ;
+      sh:name "language" ;
+    ] ;
+  sh:propertyValidator [
+      rdf:type sh:SPARQLSelectValidator ;
+      sh:message "Values are literals with language \"{?lang}\"" ;
+      sh:prefixes <http://datashapes.org/sh/tests/sparql/component/LanguageConstraintComponentUsingSELECT.test> ;
+      sh:select """
+			SELECT DISTINCT $this ?value
+			WHERE {
+				$this $PATH ?value .
+				FILTER (!isLiteral(?value) || !langMatches(lang(?value), $lang))
+			}
+			""" ;
+    ] ;
+.
+ex:LanguageExampleShape
+  rdf:type sh:NodeShape ;
+  sh:property _:b56647 ;
+  sh:property _:b71712 ;
+  sh:targetClass ex:Country ;
+.
+ex:ValidCountry1
+  rdf:type ex:Country ;
+  ex:englishLabel "Beijing"@en ;
+  ex:germanLabel "Peking"@de ;
+  rdfs:label "Valid country1" ;
+.
+ex:englishLabel
+  rdfs:domain ex:Country ;
+.
+ex:germanLabel
+  rdfs:domain ex:Country ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <propertyValidator-select-001>
+    ) ;
+.
+<propertyValidator-select-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:propertyValidator with SELECT 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidCountry1 ;
+          sh:resultPath ex:englishLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:LanguageConstraintComponentUsingSELECT ;
+          sh:sourceShape _:b56647 ;
+          sh:value "Munich" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidCountry1 ;
+          sh:resultPath ex:germanLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:LanguageConstraintComponentUsingSELECT ;
+          sh:sourceShape _:b71712 ;
+          sh:value "Muenchen" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.
+_:b56647
+  sh:path ex:englishLabel ;
+  ex:lang "en" ;
+.
+_:b71712
+  sh:path ex:germanLabel ;
+  ex:lang "de" ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/validator-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/component/validator-001.ttl
@@ -1,0 +1,81 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/component/validator-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://datashapes.org/sh/tests/sparql/component/validator-001.test>
+  owl:imports <http://datashapes.org/dash> ;
+.
+ex:ConstraintComponent
+  rdf:type rdfs:Class ;
+  rdfs:label "Constraint component" ;
+  rdfs:subClassOf sh:ConstraintComponent ;
+.
+ex:SPARQLAskValidator
+  rdfs:subClassOf sh:SPARQLAskValidator ;
+.
+ex:TestConstraintComponent
+  rdf:type ex:ConstraintComponent ;
+  rdfs:comment """A simple test component with two parameters, which flags all values as invalid unless they are the concatenation of the two parameters.
+
+Part of this test is to also use various subclasses of the system classes.""" ;
+  rdfs:label "Test constraint component" ;
+  sh:parameter ex:TestParameter1 ;
+  sh:parameter ex:TestParameter2 ;
+  sh:validator [
+      rdf:type ex:SPARQLAskValidator ;
+      sh:ask """
+ASK { FILTER (?value = CONCAT($test1, $test2)) }
+     """ ;
+    ] ;
+.
+ex:TestParameter1
+  rdf:type sh:Parameter ;
+  sh:path ex:test1 ;
+  sh:datatype xsd:string ;
+.
+ex:TestParameter2
+  rdf:type sh:Parameter ;
+  sh:path ex:test2 ;
+  sh:datatype xsd:string ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  ex:test1 "Hello " ;
+  ex:test2 "World" ;
+  rdfs:label "Test shape" ;
+  sh:targetNode "Hallo Welt" ;
+  sh:targetNode "Hello World" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <validator-001>
+    ) ;
+.
+<validator-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:validator 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode "Hallo Welt" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraintComponent ex:TestConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Hallo Welt" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/manifest.ttl
@@ -1,0 +1,11 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	mf:include <component/manifest.ttl> ;
+	mf:include <node/manifest.ttl> ;
+	mf:include <property/manifest.ttl> ;
+	mf:include <pre-binding/manifest.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/manifest.ttl
@@ -1,0 +1,12 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/sparql/node" ;
+	mf:include <prefixes-001.ttl> ;
+	mf:include <sparql-001.ttl> ;
+	mf:include <sparql-002.ttl> ;
+	mf:include <sparql-003.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/prefixes-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/prefixes-001.ttl
@@ -1,0 +1,70 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://datashapes.org/sh/tests/sparql/node/prefixes-001.test>
+  sh:declare [
+      rdf:type sh:PrefixDeclaration ;
+      sh:namespace "http://datashapes.org/sh/tests/sparql/node/prefixes-001.test#"^^xsd:anyURI ;
+      sh:prefix "ex" ;
+    ] ;
+.
+ex:InvalidResource1
+  ex:property <http://test.com/ns#Value> ;
+.
+ex:TestPrefixes
+  owl:imports <http://datashapes.org/sh/tests/sparql/node/prefixes-001.test> ;
+  sh:declare [
+      sh:namespace "http://test.com/ns#"^^xsd:anyURI ;
+      sh:prefix "test" ;
+    ] ;
+.
+ex:TestSPARQL
+  sh:prefixes ex:TestPrefixes ;
+  sh:select """
+		SELECT $this ?value
+		WHERE {
+			$this ex:property ?value .
+            FILTER (?value = test:Value) .
+		} """ ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:sparql ex:TestSPARQL ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <prefixes-001>
+    ) ;
+.
+<prefixes-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:prefixes 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestSPARQL ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value <http://test.com/ns#Value> ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/sparql-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/sparql-001.ttl
@@ -1,0 +1,89 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidResource1
+  rdf:type rdfs:Resource ;
+  rdfs:label "Invalid resource 1" ;
+.
+ex:InvalidResource2
+  rdf:type rdfs:Resource ;
+  rdfs:label "Invalid label 1" ;
+  rdfs:label "Invalid label 2" ;
+.
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource1 ;
+  sh:targetNode ex:InvalidResource2 ;
+  sh:targetNode ex:ValidResource1 ;
+.
+ex:TestShape-sparql
+  sh:message "Cannot have a label" ;
+  sh:prefixes <http://datashapes.org/sh/tests/sparql/node/sparql-001.test> ;
+  sh:select """
+  	SELECT $this ?path ?value
+	WHERE {
+		$this ?path ?value .
+		FILTER (?path = <http://www.w3.org/2000/01/rdf-schema#label>) .
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <sparql-001>
+    ) ;
+.
+<sparql-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:sparql at node shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource1 ;
+          sh:resultPath rdfs:label ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Invalid resource 1" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath rdfs:label ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Invalid label 1" ;
+        ] ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource2 ;
+          sh:resultPath rdfs:label ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value "Invalid label 2" ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/sparql-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/sparql-002.ttl
@@ -1,0 +1,69 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://datashapes.org/sh/tests/sparql/node/sparql-002.test>
+  sh:declare [
+      rdf:type sh:PrefixDeclaration ;
+      sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-002.test#"^^xsd:anyURI ;
+      sh:prefix "ex" ;
+    ] ;
+.
+ex:InvalidCountry
+  rdf:type ex:Country ;
+  ex:germanLabel "Spain"@en ;
+.
+ex:LanguageExampleShape
+  rdf:type sh:NodeShape ;
+  rdf:type sh:SPARQLConstraint ;
+  sh:message "Values are literals with German language tag." ;
+  sh:prefixes <http://datashapes.org/sh/tests/sparql/node/sparql-002.test> ;
+  sh:select """
+			SELECT $this (ex:germanLabel AS ?path) ?value
+			WHERE {
+				$this ex:germanLabel ?value .
+				FILTER (!isLiteral(?value) || !langMatches(lang(?value), \"de\"))
+			}
+			""" ;
+  sh:sparql ex:LanguageExampleShape ;
+  sh:targetClass ex:Country ;
+.
+ex:ValidCountry
+  rdf:type ex:Country ;
+  ex:germanLabel "Spanien"@de ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <sparql-002>
+    ) ;
+.
+<sparql-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:sparql at node shape 002" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidCountry ;
+          sh:resultPath ex:germanLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:LanguageExampleShape ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:LanguageExampleShape ;
+          sh:value "Spain"@en ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/sparql-003.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/node/sparql-003.ttl
@@ -1,0 +1,70 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/node/sparql-003.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://datashapes.org/sh/tests/sparql/node/sparql-003.test>
+  sh:declare [
+      rdf:type sh:PrefixDeclaration ;
+      sh:namespace "http://datashapes.org/sh/tests/sparql/node/sparql-003.test#"^^xsd:anyURI ;
+      sh:prefix "ex" ;
+    ] ;
+.
+ex:InvalidCountry
+  rdf:type ex:Country ;
+  ex:germanLabel "Spain"@en ;
+.
+ex:LanguageExampleShape
+  rdf:type sh:NodeShape ;
+  rdf:type sh:SPARQLConstraint ;
+  sh:message "Values are literals with German language tag." ;
+  sh:prefixes <http://datashapes.org/sh/tests/sparql/node/sparql-003.test> ;
+  sh:select """
+			SELECT $this (ex:germanLabel AS ?path)
+			WHERE {
+				$this ex:germanLabel ?value .
+				FILTER (!isLiteral(?value) || !langMatches(lang(?value), \"de\"))
+			}
+			""" ;
+  sh:severity sh:Warning ;
+  sh:sparql ex:LanguageExampleShape ;
+  sh:targetClass ex:Country ;
+.
+ex:ValidCountry
+  rdf:type ex:Country ;
+  ex:germanLabel "Spanien"@de ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <sparql-003>
+    ) ;
+.
+<sparql-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:sparql at node shape 003" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidCountry ;
+          sh:resultPath ex:germanLabel ;
+          sh:resultSeverity sh:Warning ;
+          sh:sourceConstraint ex:LanguageExampleShape ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:LanguageExampleShape ;
+          sh:value ex:InvalidCountry ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/manifest.ttl
@@ -1,0 +1,22 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests for pre-binding" ;
+	mf:include <pre-binding-001.ttl> ;
+	mf:include <pre-binding-002.ttl> ;
+	mf:include <pre-binding-003.ttl> ;
+	mf:include <pre-binding-004.ttl> ;
+	mf:include <pre-binding-005.ttl> ;
+	mf:include <pre-binding-006.ttl> ;
+	mf:include <pre-binding-007.ttl> ;
+	mf:include <shapesGraph-001.ttl> ;
+	mf:include <unsupported-sparql-001.ttl> ;
+	mf:include <unsupported-sparql-002.ttl> ;
+	mf:include <unsupported-sparql-003.ttl> ;
+	mf:include <unsupported-sparql-004.ttl> ;
+	mf:include <unsupported-sparql-005.ttl> ;
+	mf:include <unsupported-sparql-006.ttl> ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-001.ttl
@@ -1,0 +1,63 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-001.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:message "Test message" ;
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		FILTER ($this = ex:InvalidResource) .
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-001>
+    ) ;
+.
+<pre-binding-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in FILTER" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultMessage "Test message" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-002.ttl
@@ -1,0 +1,67 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-002.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		{
+			FILTER (false) .
+		}
+		UNION
+		{
+			FILTER ($this = ex:InvalidResource) .
+		}
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-002>
+    ) ;
+.
+<pre-binding-002>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in UNION" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-003.ttl
@@ -1,0 +1,67 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-003.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-003.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		{
+			{
+				FILTER ($this = ex:InvalidResource) .
+			}
+			FILTER bound($this) .
+		}
+		FILTER (true) .
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-003>
+    ) ;
+.
+<pre-binding-003>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in inner {...} blocks" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-004.ttl
@@ -1,0 +1,62 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		BIND ($this AS ?that) .
+		FILTER (?that = ex:InvalidResource) .
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-004>
+    ) ;
+.
+<pre-binding-004>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in BIND expressions" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-005.ttl
@@ -1,0 +1,68 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-005.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-005.test#"^^xsd:anyURI ;
+	] .
+	
+ex:InvalidResource
+	ex:property "Label" .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		{
+			FILTER (bound($this))
+		}
+		$this ex:property "Label" .
+		FILTER (bound($this)) .
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-005>
+    ) ;
+.
+<pre-binding-005>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in BGP and FILTER" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-006.ttl
@@ -1,0 +1,54 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-006.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-006.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		{
+			SELECT *
+			WHERE {
+				FILTER ($this = ex:InvalidResource) .
+			}
+		}
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-006>
+    ) ;
+.
+<pre-binding-006>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in nested SELECT" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result sht:Failure ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/pre-binding-007.ttl
@@ -1,0 +1,66 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-007.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-007.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+.
+ex:TestShape-sparql
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		{
+			SELECT $this
+			WHERE {
+				FILTER ($this = ex:InvalidResource) .
+			}
+		}
+	}""" ;
+.
+ex:ValidResource1
+  rdf:type rdfs:Resource ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <pre-binding-007>
+    ) ;
+.
+<pre-binding-007>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of pre-binding in nested SELECT" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/shapesGraph-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/shapesGraph-001.ttl
@@ -1,0 +1,64 @@
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/shapesGraph-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:
+	sh:declare [
+		sh:prefix "ex" ;
+		sh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/shapesGraph-001.test#"^^xsd:anyURI ;
+	] .
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  rdfs:label "Test shape" ;
+  sh:sparql ex:TestShape-sparql ;
+  sh:targetNode ex:InvalidResource ;
+  ex:property 42 ;
+.
+ex:TestShape-sparql
+  sh:message "Test message" ;
+  sh:prefixes ex: ;
+  sh:select """
+  	SELECT $this
+	WHERE {
+		FILTER bound($shapesGraph) .
+		GRAPH $shapesGraph {
+			FILTER bound($currentShape) .
+			$currentShape ex:property 42 . 
+		}
+	}""" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <shapesGraph-001>
+    ) ;
+.
+<shapesGraph-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of $shapesGraph and $currentShape" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidResource ;
+          sh:resultMessage "Test message" ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:TestShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:TestShape ;
+          sh:value ex:InvalidResource ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-001.ttl
@@ -1,0 +1,34 @@
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	rdf:type mf:Manifest ;
+	mf:entries ( <unsupported-sparql-001> ) .
+    
+<unsupported-sparql-001>
+	rdf:type sht:Validate ;
+	rdfs:label "Test of unsupported MINUS" ;
+	mf:action [
+		sht:dataGraph <> ;
+		sht:shapesGraph <> ;
+	] ;
+	mf:result sht:Failure ;
+	mf:status sht:approved .
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetNode ex:InvalidResource ;
+	sh:sparql [
+		sh:select """
+			SELECT $this
+			WHERE {
+				$this ?x ?any .
+				MINUS { $this ?x "Value" }
+			}""" ;
+	] .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-002.ttl
@@ -1,0 +1,33 @@
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-002.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	rdf:type mf:Manifest ;
+	mf:entries ( <unsupported-sparql-002> ) .
+    
+<unsupported-sparql-002>
+	rdf:type sht:Validate ;
+	rdfs:label "Test of unsupported VALUES" ;
+	mf:action [
+		sht:dataGraph <> ;
+		sht:shapesGraph <> ;
+	] ;
+	mf:result sht:Failure ;
+	mf:status sht:approved .
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetNode ex:InvalidResource ;
+	sh:sparql [
+		sh:select """
+			SELECT $this
+			WHERE {
+				VALUES ?any { true }
+			}""" ;
+	] .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-003.ttl
@@ -1,0 +1,36 @@
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-003.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	rdf:type mf:Manifest ;
+	mf:entries ( <unsupported-sparql-003> ) .
+    
+<unsupported-sparql-003>
+	rdf:type sht:Validate ;
+	rdfs:label "Test of unsupported SERVICE" ;
+	mf:action [
+		sht:dataGraph <> ;
+		sht:shapesGraph <> ;
+	] ;
+	mf:result sht:Failure ;
+	mf:status sht:approved .
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetNode ex:InvalidResource ;
+	sh:sparql [
+		sh:select """
+			SELECT $this
+			WHERE {
+				$this ?x ?any .
+				SERVICE <http://aldi.de> {
+					?a ?b ?c .
+				}
+			}""" ;
+	] .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-004.ttl
@@ -1,0 +1,39 @@
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-004.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	rdf:type mf:Manifest ;
+	mf:entries ( <unsupported-sparql-004> ) .
+    
+<unsupported-sparql-004>
+	rdf:type sht:Validate ;
+	rdfs:label "Test of unsupported SELECT" ;
+	mf:action [
+		sht:dataGraph <> ;
+		sht:shapesGraph <> ;
+	] ;
+	mf:result sht:Failure ;
+	mf:status sht:approved .
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetNode ex:InvalidResource ;
+	sh:sparql [
+		sh:select """
+			SELECT $this
+			WHERE {
+				$this ?x ?any .
+				{
+					SELECT ?other ?b 
+					WHERE {
+						?other ?b ?c .
+					}
+				}
+			}""" ;
+	] .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-005.ttl
@@ -1,0 +1,33 @@
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-005.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	rdf:type mf:Manifest ;
+	mf:entries ( <unsupported-sparql-005> ) .
+    
+<unsupported-sparql-005>
+	rdf:type sht:Validate ;
+	rdfs:label "Test of unsupported AS ?prebound" ;
+	mf:action [
+		sht:dataGraph <> ;
+		sht:shapesGraph <> ;
+	] ;
+	mf:result sht:Failure ;
+	mf:status sht:approved .
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:targetNode ex:InvalidResource ;
+	sh:sparql [
+		sh:select """
+			SELECT $this
+			WHERE {
+				BIND (true AS $this) .
+			}""" ;
+	] .

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/pre-binding/unsupported-sparql-006.ttl
@@ -1,0 +1,85 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/unsupported-sparql-006.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Country
+  rdf:type rdfs:Class ;
+  rdfs:label "Country" ;
+.
+ex:InvalidCountry1
+  rdf:type ex:Country ;
+  ex:englishLabel "Munich" ;
+  ex:germanLabel "Muenchen" ;
+  rdfs:label "Invalid country1" ;
+.
+ex:LanguageConstraintComponentUsingASK
+  rdf:type sh:ConstraintComponent ;
+  rdfs:label "Language constraint component" ;
+  sh:labelTemplate "Values are literals with language \"{$lang}\"" ;
+  sh:parameter [
+      sh:path ex:lang ;
+      sh:datatype xsd:string ;
+      sh:description "The language tag, e.g. \"de\"." ;
+      sh:minLength 2 ;
+      sh:name "language" ;
+    ] ;
+  sh:propertyValidator ex:hasLang ;
+.
+ex:LanguageExampleShape
+  rdf:type sh:NodeShape ;
+  sh:property _:b41651 ;
+  sh:property _:b75747 ;
+  sh:targetClass ex:Country ;
+.
+ex:ValidCountry1
+  rdf:type ex:Country ;
+  ex:englishLabel "Beijing"@en ;
+  ex:germanLabel "Peking"@de ;
+  rdfs:label "Valid country1" ;
+.
+ex:englishLabel
+  rdfs:domain ex:Country ;
+.
+ex:germanLabel
+  rdfs:domain ex:Country ;
+.
+ex:hasLang
+  rdf:type sh:SPARQLAskValidator ;
+  sh:ask """
+			ASK {
+				BIND (true AS ?value) .
+				FILTER (isLiteral(?value) && langMatches(lang(?value), $lang))
+			}
+			""" ;
+  sh:message "Values are literals with language \"{?lang}\"" ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <unsupported-sparql-006>
+    ) ;
+.
+<unsupported-sparql-006>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of ASK trying to reassign ?value" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result sht:Failure ;
+  mf:status sht:approved ;
+.
+_:b41651
+  sh:path ex:englishLabel ;
+  ex:lang "en" ;
+.
+_:b75747
+  sh:path ex:germanLabel ;
+  ex:lang "de" ;
+.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/property/manifest.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/property/manifest.ttl
@@ -1,0 +1,9 @@
+@prefix mf:      <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sht:     <http://www.w3.org/ns/shacl-test#> .
+
+<>
+	a mf:Manifest ;
+	rdfs:label "Tests converted from http://datashapes.org/sh/tests/tests/sparql/property" ;
+	mf:include <sparql-001.ttl> ;
+	.

--- a/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/property/sparql-001.ttl
+++ b/shacl/src/main/resources/data-shapes-test-suite/tests/sparql/property/sparql-001.ttl
@@ -1,0 +1,68 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix ex: <http://datashapes.org/sh/tests/sparql/property/sparql-001.test#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sht: <http://www.w3.org/ns/shacl-test#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Country
+  rdf:type rdfs:Class ;
+.
+ex:InvalidCountry
+  rdf:type ex:Country ;
+  ex:germanLabel "Spain"@en ;
+.
+ex:LanguageExamplePropertyShape
+  rdf:type sh:PropertyShape ;
+  sh:path ex:germanLabel ;
+  sh:sparql ex:LanguageExamplePropertyShape-sparql ;
+  sh:targetClass ex:Country ;
+.
+ex:LanguageExamplePropertyShape-sparql
+  rdf:type sh:SPARQLConstraint ;
+  sh:message "Values are literals with German language tag." ;
+  sh:prefixes ex: ;
+  sh:select """
+		SELECT $this ?value
+		WHERE {
+			$this $PATH ?value .
+			FILTER (!isLiteral(?value) || !langMatches(lang(?value), \"de\"))
+		}
+		""" ;
+.
+ex:ValidCountry
+  rdf:type ex:Country ;
+  ex:germanLabel "Spanien"@de ;
+.
+<>
+  rdf:type mf:Manifest ;
+  mf:entries (
+      <sparql-001>
+    ) ;
+.
+<sparql-001>
+  rdf:type sht:Validate ;
+  rdfs:label "Test of sh:sparql at property shape 001" ;
+  mf:action [
+      sht:dataGraph <> ;
+      sht:shapesGraph <> ;
+    ] ;
+  mf:result [
+      rdf:type sh:ValidationReport ;
+      sh:conforms "false"^^xsd:boolean ;
+      sh:result [
+          rdf:type sh:ValidationResult ;
+          sh:focusNode ex:InvalidCountry ;
+          sh:resultPath ex:germanLabel ;
+          sh:resultSeverity sh:Violation ;
+          sh:sourceConstraint ex:LanguageExamplePropertyShape-sparql ;
+          sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+          sh:sourceShape ex:LanguageExamplePropertyShape ;
+          sh:value "Spain"@en ;
+        ] ;
+    ] ;
+  mf:status sht:approved ;
+.


### PR DESCRIPTION
This PR addresses GitHub issue: #20 .

* Import test suite from https://github.com/w3c/data-shapes/tree/gh-pages/data-shapes-test-suite/tests
* Create junit test suite from it
