### PR TITLE
GeoSPARQL testcase for distance function as part of math expression

### DIFF
--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -26,6 +27,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
@@ -242,16 +244,16 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 		TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, queryStr);
 		query.setBinding("from", TEST_POINT);
 		query.setBinding("units", GEOF.UOM_METRE);
-		query.setBinding("range", sail.getValueFactory().createLiteral(1500.0));
+		query.setBinding("range", sail.getValueFactory().createLiteral(1.5));
 
-		TupleQueryResult result = query.evaluate();
+		List<BindingSet> result = QueryResults.asList(query.evaluate());
 
 		// check the results
 		Map<IRI, Literal> expected = new LinkedHashMap<IRI, Literal>();
 		expected.put(SUBJECT_1, sail.getValueFactory().createLiteral(760.0 / 1000.0));
 
-		while (result.hasNext()) {
-			BindingSet bindings = result.next();
+		for (BindingSet bindings: result) {
+			System.out.println(bindings);
 			IRI subj = (IRI)bindings.getValue("toUri");
 			// check ordering
 			IRI expectedUri = expected.keySet().iterator().next();
@@ -264,7 +266,7 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 			assertNotNull(bindings.getValue("g"));
 		}
 		assertTrue(expected.isEmpty());
-		result.close();
+
 	}
 
 	public void testIntersectionQuery()

--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
@@ -16,10 +16,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.URI;
-import org.eclipse.rdf4j.model.impl.LiteralImpl;
-import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -32,7 +32,6 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
 import org.junit.Before;
@@ -40,37 +39,39 @@ import org.junit.Test;
 
 public abstract class AbstractLuceneSailGeoSPARQLTest {
 
-	public static final URI SUBJECT_1 = new URIImpl("urn:subject1");
+	private static final ValueFactory vf = SimpleValueFactory.getInstance();
+	
+	public static final IRI SUBJECT_1 = vf.createIRI("urn:subject1");
 
-	public static final URI SUBJECT_2 = new URIImpl("urn:subject2");
+	public static final IRI SUBJECT_2 = vf.createIRI("urn:subject2");
 
-	public static final URI SUBJECT_3 = new URIImpl("urn:subject3");
+	public static final IRI SUBJECT_3 = vf.createIRI("urn:subject3");
 
-	public static final URI SUBJECT_4 = new URIImpl("urn:subject4");
+	public static final IRI SUBJECT_4 = vf.createIRI("urn:subject4");
 
-	public static final URI SUBJECT_5 = new URIImpl("urn:subject5");
+	public static final IRI SUBJECT_5 = vf.createIRI("urn:subject5");
 
-	public static final URI CONTEXT_1 = new URIImpl("urn:context1");
+	public static final IRI CONTEXT_1 = vf.createIRI("urn:context1");
 
-	public static final URI CONTEXT_2 = new URIImpl("urn:context2");
+	public static final IRI CONTEXT_2 = vf.createIRI("urn:context2");
 
-	public static final URI CONTEXT_3 = new URIImpl("urn:context3");
+	public static final IRI CONTEXT_3 = vf.createIRI("urn:context3");
 
-	public static final Literal EIFFEL_TOWER = new LiteralImpl("POINT (2.2945 48.8582)", GEO.WKT_LITERAL);
+	public static final Literal EIFFEL_TOWER = vf.createLiteral("POINT (2.2945 48.8582)", GEO.WKT_LITERAL);
 
-	public static final Literal ARC_TRIOMPHE = new LiteralImpl("POINT (2.2950 48.8738)", GEO.WKT_LITERAL);
+	public static final Literal ARC_TRIOMPHE = vf.createLiteral("POINT (2.2950 48.8738)", GEO.WKT_LITERAL);
 
-	public static final Literal NOTRE_DAME = new LiteralImpl("POINT (2.3465 48.8547)", GEO.WKT_LITERAL);
+	public static final Literal NOTRE_DAME = vf.createLiteral("POINT (2.3465 48.8547)", GEO.WKT_LITERAL);
 
-	public static final Literal POLY1 = new LiteralImpl(
+	public static final Literal POLY1 = vf.createLiteral(
 			"POLYGON ((2.3294 48.8726, 2.2719 48.8643, 2.3370 48.8398, 2.3294 48.8726))", GEO.WKT_LITERAL);
 
-	public static final Literal POLY2 = new LiteralImpl(
+	public static final Literal POLY2 = vf.createLiteral(
 			"POLYGON ((2.3509 48.8429, 2.3785 48.8385, 2.3576 48.8487, 2.3509 48.8429))", GEO.WKT_LITERAL);
 
-	public static final Literal TEST_POINT = new LiteralImpl("POINT (2.2871 48.8630)", GEO.WKT_LITERAL);
+	public static final Literal TEST_POINT = vf.createLiteral("POINT (2.2871 48.8630)", GEO.WKT_LITERAL);
 
-	public static final Literal TEST_POLY = new LiteralImpl(
+	public static final Literal TEST_POLY = vf.createLiteral(
 			"POLYGON ((2.315 48.855, 2.360 48.835, 2.370 48.850, 2.315 48.855))", GEO.WKT_LITERAL);
 
 	private static final double ERROR = 2.0;
@@ -177,15 +178,15 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 		TupleQueryResult result = query.evaluate();
 
 		// check the results
-		Map<URI, Literal> expected = new LinkedHashMap<URI, Literal>();
+		Map<IRI, Literal> expected = new LinkedHashMap<IRI, Literal>();
 		expected.put(SUBJECT_1, EIFFEL_TOWER);
 		expected.put(SUBJECT_2, ARC_TRIOMPHE);
 
 		while (result.hasNext()) {
 			BindingSet bindings = result.next();
-			URI subj = (URI)bindings.getValue("toUri");
+			IRI subj = (IRI)bindings.getValue("toUri");
 			// check ordering
-			URI expectedUri = expected.keySet().iterator().next();
+			IRI expectedUri = expected.keySet().iterator().next();
 			assertEquals(expectedUri, subj);
 
 			Literal location = expected.remove(subj);
@@ -211,14 +212,49 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 		TupleQueryResult result = query.evaluate();
 
 		// check the results
-		Map<URI, Literal> expected = new LinkedHashMap<URI, Literal>();
+		Map<IRI, Literal> expected = new LinkedHashMap<IRI, Literal>();
 		expected.put(SUBJECT_1, sail.getValueFactory().createLiteral(760.0));
 
 		while (result.hasNext()) {
 			BindingSet bindings = result.next();
-			URI subj = (URI)bindings.getValue("toUri");
+			IRI subj = (IRI)bindings.getValue("toUri");
 			// check ordering
-			URI expectedUri = expected.keySet().iterator().next();
+			IRI expectedUri = expected.keySet().iterator().next();
+			assertEquals(expectedUri, subj);
+
+			Literal dist = expected.remove(subj);
+			assertNotNull(dist);
+			assertEquals(dist.doubleValue(), ((Literal)bindings.getValue("dist")).doubleValue(), ERROR);
+
+			assertNotNull(bindings.getValue("g"));
+		}
+		assertTrue(expected.isEmpty());
+		result.close();
+	}
+	
+	@Test
+	public void testComplexDistanceQueryMathExpr()
+		throws RepositoryException, MalformedQueryException, QueryEvaluationException
+	{
+		String queryStr = "prefix geo:  <" + GEO.NAMESPACE + ">" + "prefix geof: <" + GEOF.NAMESPACE + ">"
+				+ "select ?toUri ?dist ?g where { graph ?g {?toUri geo:asWKT ?to.}"
+				+ " bind((geof:distance(?from, ?to, ?units) / 1000) as ?dist)" + " filter(?dist < ?range)" + " }";
+		TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, queryStr);
+		query.setBinding("from", TEST_POINT);
+		query.setBinding("units", GEOF.UOM_METRE);
+		query.setBinding("range", sail.getValueFactory().createLiteral(1500.0));
+
+		TupleQueryResult result = query.evaluate();
+
+		// check the results
+		Map<IRI, Literal> expected = new LinkedHashMap<IRI, Literal>();
+		expected.put(SUBJECT_1, sail.getValueFactory().createLiteral(760.0 / 1000.0));
+
+		while (result.hasNext()) {
+			BindingSet bindings = result.next();
+			IRI subj = (IRI)bindings.getValue("toUri");
+			// check ordering
+			IRI expectedUri = expected.keySet().iterator().next();
 			assertEquals(expectedUri, subj);
 
 			Literal dist = expected.remove(subj);
@@ -242,13 +278,13 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 		TupleQueryResult result = query.evaluate();
 
 		// check the results
-		Map<URI, Literal> expected = new HashMap<URI, Literal>();
+		Map<IRI, Literal> expected = new HashMap<IRI, Literal>();
 		expected.put(SUBJECT_4, POLY1);
 		expected.put(SUBJECT_5, POLY2);
 
 		while (result.hasNext()) {
 			BindingSet bindings = result.next();
-			URI subj = (URI)bindings.getValue("matchUri");
+			IRI subj = (IRI)bindings.getValue("matchUri");
 
 			Literal location = expected.remove(subj);
 			assertNotNull(location);
@@ -270,12 +306,12 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 		TupleQueryResult result = query.evaluate();
 
 		// check the results
-		Map<URI, Literal> expected = new HashMap<URI, Literal>();
+		Map<IRI, Literal> expected = new HashMap<IRI, Literal>();
 		expected.put(SUBJECT_5, sail.getValueFactory().createLiteral(true));
 
 		while (result.hasNext()) {
 			BindingSet bindings = result.next();
-			URI subj = (URI)bindings.getValue("matchUri");
+			IRI subj = (IRI)bindings.getValue("matchUri");
 
 			Literal location = expected.remove(subj);
 			assertNotNull("Expected subject: " + subj, location);


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j-storage#87 

Briefly describe the changes proposed in this PR:

* added new test cases for bug described in eclipse/rdf4j-storage#87
* needs review as this test case currently fails in both Solr and Lucene, even with a proposed fix in Lucene in place.

@pulquero I could use your help on this. Can you try this added test in the Lucene and Solr sails and check if you see any obvious things I overlooked? Also see related Pull Request https://github.com/eclipse/rdf4j-storage/pull/88