### PR TITLE
Changed assertj-core to 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.10.0</version>
+				<version>3.9.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1157 .

Briefly describe the changes proposed in this PR:

* Changed assertj-core version to 3.9.1 
