### PR TITLE
benchmarks shaded jar fails on downloading source deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<configuration>
-							<createSourcesJar>true</createSourcesJar>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1193 .

Testsuite build failed. This is unrelated to my actual fixes for the above issue, but seems to have something to do with the configuration for the shaded jar produced for the benchmarks. For some reason it was configured to also create a shaded source jar, which fails (I couldn't quite figure out _why_, to be honest). But given that I don't believe we actually _need_ a shaded source jar, I tweaked the config to just not produce one.