### PR TITLE
eclipse/rdf4j#1195 bump maven shade plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.2.1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1195 .

Briefly describe the changes proposed in this PR:

* bump shade plugin version
