### PR TITLE
GH-1230 don't reuse createRepository, just read directly to model

### DIFF
--- a/store/pom.xml
+++ b/store/pom.xml
@@ -26,6 +26,12 @@
 
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-ntriples</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-queryresultio-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1230 .

Briefly describe the changes proposed in this PR:

minor fix in Inferencing test: don't use createRepository for processing the expected output data (may cause file name conflict), instead just read directly to a model.
