### PR TITLE
Use buffered streams

### DIFF
--- a/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestObject.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestObject.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.base;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -241,8 +243,9 @@ public abstract class AbstractTestObject extends BulkTest {
 	protected void writeExternalFormToDisk(Serializable o, String path)
 		throws IOException
 	{
-		FileOutputStream fileStream = new FileOutputStream(path);
-		writeExternalFormToStream(o, fileStream);
+		try (OutputStream fileStream = new BufferedOutputStream(new FileOutputStream(path))) {
+			writeExternalFormToStream(o, fileStream);
+		}
 	}
 
 	/**
@@ -274,7 +277,7 @@ public abstract class AbstractTestObject extends BulkTest {
 	protected Object readExternalFormFromDisk(String path)
 		throws IOException, ClassNotFoundException
 	{
-		FileInputStream stream = new FileInputStream(path);
+		InputStream stream = new BufferedInputStream(new FileInputStream(path));
 		return readExternalFormFromStream(stream);
 	}
 

--- a/rio/src/main/java/org/eclipse/rdf4j/rio/EarlReport.java
+++ b/rio/src/main/java/org/eclipse/rdf4j/rio/EarlReport.java
@@ -7,17 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import junit.framework.AssertionFailedError;
 import junit.framework.Test;
 import junit.framework.TestListener;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
-
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -36,6 +30,13 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * @author Arjohn Kampman
@@ -139,12 +140,8 @@ public class EarlReport {
 				Rio.unsupportedFormat(RDFFormat.TURTLE));
 		File outFile = File.createTempFile("sesame-earl-compliance",
 				"." + RDFFormat.TURTLE.getDefaultFileExtension());
-		FileOutputStream out = new FileOutputStream(outFile);
-		try {
+		try (OutputStream out = new BufferedOutputStream(new FileOutputStream(outFile))) {
 			con.export(factory.getWriter(out));
-		}
-		finally {
-			out.close();
 		}
 
 		con.close();

--- a/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -7,27 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -58,6 +37,29 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Arjohn Kampman
@@ -749,8 +751,8 @@ public abstract class RDFWriterTest {
 		File testFile = tempDir.newFile(
 				"performancetest." + rdfWriterFactory.getRDFFormat().getDefaultFileExtension());
 
-		FileOutputStream out = new FileOutputStream(testFile);
-		try {
+		try (OutputStream out = new BufferedOutputStream(new FileOutputStream(testFile))) {
+
 			long startWrite = System.currentTimeMillis();
 			RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
 			setupWriterConfig(rdfWriter.getWriterConfig());
@@ -769,15 +771,13 @@ public abstract class RDFWriterTest {
 			rdfWriter.endRDF();
 			long endWrite = System.currentTimeMillis();
 			System.out.println("Write took: " + (endWrite - startWrite) + " ms ("
-					+ rdfWriterFactory.getRDFFormat() + ")");
+				+ rdfWriterFactory.getRDFFormat() + ")");
 			System.out.println("File size (bytes): " + testFile.length());
-		}
-		finally {
-			out.close();
+
 		}
 
-		FileInputStream in = new FileInputStream(testFile);
-		try {
+		try (InputStream in = new BufferedInputStream(new FileInputStream(testFile))) {
+
 			RDFParser rdfParser = rdfParserFactory.getParser();
 			setupParserConfig(rdfParser.getParserConfig());
 			rdfParser.setValueFactory(vf);
@@ -789,7 +789,7 @@ public abstract class RDFWriterTest {
 			rdfParser.parse(in, "foo:bar");
 			long endParse = System.currentTimeMillis();
 			System.out.println("Parse took: " + (endParse - startParse) + " ms ("
-					+ rdfParserFactory.getRDFFormat() + ")");
+				+ rdfParserFactory.getRDFFormat() + ")");
 
 			if (storeParsedStatements) {
 				if (model.size() != parsedModel.size()) {
@@ -801,23 +801,20 @@ public abstract class RDFWriterTest {
 
 						System.out.println("Written statements=>");
 						IOUtils.writeLines(IOUtils.readLines(new FileInputStream(testFile)), "\n",
-								System.out);
+							System.out);
 						System.out.println("Parsed statements=>");
 						Rio.write(parsedModel, System.out, RDFFormat.NQUADS);
 					}
 				}
 				assertEquals("Unexpected number of statements, expected " + model.size() + " found "
-						+ parsedModel.size(), model.size(), parsedModel.size());
+					+ parsedModel.size(), model.size(), parsedModel.size());
 
 				if (rdfParser.getRDFFormat().supportsNamespaces()) {
 					assertTrue("Expected at least 5 namespaces, found " + parsedModel.getNamespaces().size(),
-							parsedModel.getNamespaces().size() >= 5);
+						parsedModel.getNamespaces().size() >= 5);
 					assertEquals(exNs, parsedModel.getNamespace("ex").get().getName());
 				}
 			}
-		}
-		finally {
-			in.close();
 		}
 	}
 

--- a/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11SyntaxTest.java
+++ b/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11SyntaxTest.java
@@ -7,11 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql.manifest;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
@@ -212,11 +214,11 @@ public abstract class SPARQL11SyntaxTest extends TestCase {
 							continue;
 						}
 						InputStream is = jar.getInputStream(file);
-						FileOutputStream fos = new FileOutputStream(f);
-						while (is.available() > 0) {
-							fos.write(is.read());
+						try (OutputStream fos = new BufferedOutputStream(new FileOutputStream(f))) {
+							while (is.available() > 0) {
+								fos.write(is.read());
+							}
 						}
-						fos.close();
 						is.close();
 					}
 					File localFile = new File(tmpDir, con.getEntryName());

--- a/store/src/main/java/org/eclipse/rdf4j/sail/InferencingTest.java
+++ b/store/src/main/java/org/eclipse/rdf4j/sail/InferencingTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail;
 
 import static org.junit.Assert.fail;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
@@ -129,7 +130,7 @@ public abstract class InferencingTest {
 		File tmpFile = new File(tmpDir, "junit-" + name + ".nt");
 		tmpFile.createNewFile();
 
-		try (OutputStream export = new FileOutputStream(tmpFile);) {
+		try (OutputStream export = new BufferedOutputStream(new FileOutputStream(tmpFile))) {
 			RDFWriter writer = Rio.createWriter(RDFFormat.NTRIPLES, export);
 
 			writer.startRDF();


### PR DESCRIPTION

This PR addresses GitHub issue: eclipse/rdf4j#1335 .

Briefly describe the changes proposed in this PR:

* use buffered input and output streams
* use try-with-resource
