### PR TITLE
GH-1236 model testsuite scheduled for removal in next major - mark deprecated

### DIFF
--- a/model/src/main/java/org/eclipse/rdf4j/model/ModelEqualityTest.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/ModelEqualityTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 /**
  * @author Arjohn Kampman
  */
+@Deprecated
 public abstract class ModelEqualityTest {
 
 	public static final String TESTCASES_DIR = "/testcases/model/equality/";

--- a/model/src/main/java/org/eclipse/rdf4j/model/ModelNamespacesTest.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/ModelNamespacesTest.java
@@ -30,7 +30,9 @@ import org.junit.Test;
  * An abstract test class to test the handling of namespaces by {@link Model} implementations.
  * 
  * @author Peter Ansell p_ansell@yahoo.com
+ * @deprecated moved to test package of rdf4j-model
  */
+@Deprecated
 public abstract class ModelNamespacesTest {
 
 	private Model testModel;

--- a/model/src/main/java/org/eclipse/rdf4j/model/ModelTest.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/ModelTest.java
@@ -25,6 +25,11 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+/**
+ * 
+ * @deprecated replaced with ModelCollectionTest in rdf4j-model unit test suite.
+ */
+@Deprecated
 public abstract class ModelTest extends TestCase {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();

--- a/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestCollection.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestCollection.java
@@ -98,6 +98,7 @@ import java.util.NoSuchElementException;
  * @author Neil O'Toole
  * @author Stephen Colebourne
  */
+@Deprecated
 public abstract class AbstractTestCollection extends AbstractTestObject {
 
 	//

--- a/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestObject.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestObject.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
  * @author Stephen Colebourne
  * @author Anonymous
  */
+@Deprecated
 public abstract class AbstractTestObject extends BulkTest {
 
 	/** Current major release for Collections */

--- a/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestSet.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/base/AbstractTestSet.java
@@ -27,6 +27,7 @@ import java.util.Set;
  * @version $Revision: 646780 $ $Date: 2008-04-10 13:48:07 +0100 (Thu, 10 Apr 2008) $
  * @author Paul Jack
  */
+@Deprecated
 public abstract class AbstractTestSet extends AbstractTestCollection {
 
 	/**

--- a/model/src/main/java/org/eclipse/rdf4j/model/base/ApacheSetTestCase.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/base/ApacheSetTestCase.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
  * Extends the Apache Commons Collections test, {@link AbstractTestSet} to enable testing of the OpenRDF Model
  * collection implementations.
  */
+@Deprecated
 public abstract class ApacheSetTestCase extends AbstractTestSet {
 
 	private ValueFactory vf = SimpleValueFactory.getInstance();

--- a/model/src/main/java/org/eclipse/rdf4j/model/base/BulkTest.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/base/BulkTest.java
@@ -116,6 +116,7 @@ import junit.framework.TestSuite;
  * @author Paul Jack
  * @version $Id: BulkTest.java 646780 2008-04-10 12:48:07Z niallp $
  */
+@Deprecated
 public abstract class BulkTest extends TestCase implements Cloneable {
 
 	// Note: BulkTest is Cloneable to make it easier to construct


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1236 .

